### PR TITLE
Added a way to create a capture for a specific camera

### DIFF
--- a/src/OpenCV/VideoIO/VideoCapture.hs
+++ b/src/OpenCV/VideoIO/VideoCapture.hs
@@ -6,6 +6,7 @@ module OpenCV.VideoIO.VideoCapture
   , VideoCaptureSource(..)
 
   , newVideoCapture
+  , newVideoCaptureUsingIndex
   , videoCaptureOpen
   , videoCaptureRelease
   , videoCaptureIsOpened
@@ -57,6 +58,12 @@ newVideoCapture :: IO VideoCapture
 newVideoCapture = fromPtr $
     [CU.exp|VideoCapture * {
       new cv::VideoCapture()
+    }|]
+
+newVideoCaptureUsingIndex :: C.CInt -> IO VideoCapture
+newVideoCaptureUsingIndex i = fromPtr $
+    [CU.exp|VideoCapture * {
+      new cv::VideoCapture($(int i))
     }|]
 
 videoCaptureOpen :: VideoCapture -> VideoCaptureSource -> CvExceptT IO ()


### PR DESCRIPTION
On my system cv::VideoCapture() doesn't work unless I supply and index. I therefore have added a method that allows to specify which camera is to be used.