### PR TITLE
HighGui's destroyWindow needs to wait otherwise it segfauilts

### DIFF
--- a/examples/src/highgui.hs
+++ b/examples/src/highgui.hs
@@ -7,4 +7,5 @@ main = do
     img <- CV.imdecode CV.ImreadUnchanged <$> B.readFile "data/Lenna.png"
     CV.withWindow "test" $ \window -> do
       CV.imshow window img
-      void $ CV.waitKey 10000
+      -- 0 will wait forever for a keypress
+      void $ CV.waitKey 0

--- a/src/OpenCV/HighGui.hsc
+++ b/src/OpenCV/HighGui.hsc
@@ -82,6 +82,8 @@ C.context (C.cppCtx <> openCvCtx)
 
 C.include "opencv2/core.hpp"
 C.include "opencv2/highgui.hpp"
+C.include "chrono"
+C.include "thread"
 C.using "namespace cv"
 
 #include <bindings.dsl.h>
@@ -146,7 +148,10 @@ makeWindow title = do
 -- | Close the window and free up all resources associated with the window.
 destroyWindow :: Window -> IO ()
 destroyWindow window = mask_ $ do
-    [C.exp| void { cv::destroyWindow($(char * c'name)); }|]
+    [C.block| void {
+       cv::destroyWindow($(char * c'name));
+       std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }|]
     free c'name
     modifyMVar_ (windowMouseCallback window) $ \mbMouseCallback -> do
       mapM_ freeHaskellFunPtr mbMouseCallback


### PR DESCRIPTION
Looks like multithreading is causing segfaults in `destroyWindow`.
The `100ms` is an empiric value. It looks like the actual window destroying is happening on a separate thread. I tried [`threadDelay`](https://hackage.haskell.org/package/base-4.9.0.0/docs/Control-Concurrent.html#v:threadDelay) after the `C.` block but it was too late.