### PR TITLE
wrap `cv::denoise_TVL1`

### DIFF
--- a/src/OpenCV/Core/ArrayOps.hs
+++ b/src/OpenCV/Core/ArrayOps.hs
@@ -29,6 +29,7 @@ module OpenCV.Core.ArrayOps
       -- * Channel operations
     , matMerge
     , matSplit
+    , matChannelMapM
       -- * Other
     , minMaxLoc
     , NormType(..)
@@ -608,6 +609,16 @@ matSplit src = unsafePerformIO $
 
 <http://docs.opencv.org/3.0-last-rst/modules/core/doc/operations_on_arrays.html#minmaxloc OpenCV Sphinx doc>
 -}
+
+{- | Apply the same 1 dimensional action to every channel
+-}
+matChannelMapM
+   :: Monad m
+   => (Mat shape ('S 1) depth -> m (Mat shape ('S 1) depth))
+   -> Mat shape channelsOut depth
+   -> m (Mat shape channelsOut depth)
+matChannelMapM f img = unsafeCoerceMat . matMerge <$> V.mapM f (matSplit img)
+
 
 -- TODO (RvD): implement mask
 minMaxLoc

--- a/src/OpenCV/Core/ArrayOps.hs
+++ b/src/OpenCV/Core/ArrayOps.hs
@@ -605,11 +605,6 @@ matSplit src = unsafePerformIO $
     c'numChans :: Int32
     c'numChans = fromIntegral numChans
 
-{- | Finds the global minimum and maximum in an array
-
-<http://docs.opencv.org/3.0-last-rst/modules/core/doc/operations_on_arrays.html#minmaxloc OpenCV Sphinx doc>
--}
-
 {- | Apply the same 1 dimensional action to every channel
 -}
 matChannelMapM
@@ -619,7 +614,10 @@ matChannelMapM
    -> m (Mat shape channelsOut depth)
 matChannelMapM f img = unsafeCoerceMat . matMerge <$> V.mapM f (matSplit img)
 
+{- | Finds the global minimum and maximum in an array
 
+<http://docs.opencv.org/3.0-last-rst/modules/core/doc/operations_on_arrays.html#minmaxloc OpenCV Sphinx doc>
+-}
 -- TODO (RvD): implement mask
 minMaxLoc
     :: Mat ('S [height, width]) channels depth -- ^

--- a/src/OpenCV/Photo.hs
+++ b/src/OpenCV/Photo.hs
@@ -9,6 +9,7 @@
 module OpenCV.Photo
   ( InpaintingMethod(..)
   , inpaint
+  , denoise_TVL1
   , fastNlMeansDenoisingColored
   , fastNlMeansDenoisingColoredMulti
   ) where
@@ -112,7 +113,8 @@ inpaint inpaintRadius method src inpaintMask = unsafeWrapException $ do
     c'method = marshalInpaintingMethod method
     c'inpaintRadius = realToFrac inpaintRadius
 
-{- | Preform fastNlMeansDenoising function for colored images.
+{- | Preform fastNlMeansDenoising function for colored images. Denoising is not
+     per channel but in a different colour space
 
 Example:
 
@@ -123,7 +125,7 @@ fastNlMeansDenoisingColoredImg
        , w2 ~ ((*) w 2)
        )
     => Mat ('S ['S h, 'S w2]) ('S c) ('S d)
-fastNlMeansDenoisingColoredImg= exceptError $ do
+fastNlMeansDenoisingColoredImg = exceptError $ do
     denoised <- fastNlMeansDenoisingColored 3 10 7 21 lenna_512x512
     withMatM
       (Proxy :: Proxy [h, w2])
@@ -141,19 +143,24 @@ fastNlMeansDenoisingColoredImg= exceptError $ do
 
 fastNlMeansDenoisingColored
    :: Double -- ^ Parameter regulating filter strength for luminance component.
-             -- Bigger h value perfectly removes noise but also removes image details,
-             -- smaller h value preserves details but also preserves some noise
-   -> Double -- ^ The same as h but for color components. For most images value equals 10 will be enough
-             -- to remove colored noise and do not distort colors
-   -> Int32  -- ^ templateWindowSize Size in pixels of the template patch that is used to compute weights.
+             -- Bigger h value perfectly removes noise but also removes image
+             -- details, smaller h value preserves details but also preserves
+             -- some noise
+   -> Double -- ^ The same as h but for color components. For most images value
+             -- equals 10 will be enough to remove colored noise and do not
+             -- distort colors
+   -> Int32  -- ^ templateWindowSize Size in pixels of the template patch that
+             -- is used to compute weights.
              -- Should be odd. Recommended value 7 pixels
-   -> Int32  -- ^ searchWindowSize. Size in pixels of the window that is used to compute weighted average
-             -- for given pixel. Should be odd. Affect performance linearly:
-             -- greater searchWindowsSize - greater denoising time.
-             -- Recommended value 21 pixels
+   -> Int32  -- ^ searchWindowSize. Size in pixels of the window that is used
+             -- to compute weighted average for given pixel. Should be odd.
+             -- Affect performance linearly: greater searchWindowsSize
+             -- - greater denoising time. Recommended value 21 pixels
    -> Mat ('S [h, w]) ('S 3) ('S Word8) -- ^ Input image 8-bit 3-channel image.
-   -> CvExcept (Mat ('S [h, w]) ('S 3) ('S Word8)) -- ^ Output image same size and type as input.
-fastNlMeansDenoisingColored h hColor templateWindowSize searchWindowSize src = unsafeWrapException $ do
+   -> CvExcept (Mat ('S [h, w]) ('S 3) ('S Word8))
+             -- ^ Output image same size and type as input.
+fastNlMeansDenoisingColored h hColor templateWindowSize searchWindowSize src =
+  unsafeWrapException $ do
     dst <- newEmptyMat
     handleCvException (pure $ unsafeCoerceMat dst) $
       withPtr src         $ \srcPtr         ->
@@ -172,11 +179,12 @@ fastNlMeansDenoisingColored h hColor templateWindowSize searchWindowSize src = u
     c'hColor = realToFrac hColor
 
 {- | Preform fastNlMeansDenoisingColoredMulti function for colored images.
-     it differs from the original OpenCV version by using all input images
-     and denoising the middle one. The original version would allow to have
-     some arbitrary length vector and slide window over it. As we have to copy the haskell vector
-     before we can use it as `std::vector` on the cpp side it is easier to trim the vector before sending
-     and use all frames.
+     Denoising is not pre channel but in a different colour space.
+     This wrapper differs from the original OpenCV version by using all input
+     images and denoising the middle one. The original version would allow
+     to have some arbitrary length vector and slide window over it. As we have
+     to copy the haskell vector before we can use it as `std::vector` on the cpp
+     side it is easier to trim the vector before sending and use all frames.
 
 Example:
 
@@ -205,26 +213,33 @@ fastNlMeansDenoisingColoredMultiImg = exceptError $ do
 
 fastNlMeansDenoisingColoredMulti
    :: Double -- ^ Parameter regulating filter strength for luminance component.
-             -- Bigger h value perfectly removes noise but also removes image details,
-             -- smaller h value preserves details but also preserves some noise
-   -> Double -- ^ The same as h but for color components. For most images value equals 10 will be enough
-             -- to remove colored noise and do not distort colors
-   -> Int32  -- ^ templateWindowSize Size in pixels of the template patch that is used to compute weights.
-             -- Should be odd. Recommended value 7 pixels
-   -> Int32  -- ^ searchWindowSize. Size in pixels of the window that is used to compute weighted average
-             -- for given pixel. Should be odd. Affect performance linearly:
-             -- greater searchWindowsSize - greater denoising time.
-             -- Recommended value 21 pixels
-   -> V.Vector (Mat ('S [h, w]) ('S 3) ('S Word8)) -- ^ Vector of odd number of input 8-bit 3-channel images.
-   -> CvExcept (Mat ('S [h, w]) ('S 3) ('S Word8)) -- ^ Output image same size and type as input.
+             -- Bigger h value perfectly removes noise but also removes image
+             -- details, smaller h value preserves details but also preserves
+             -- some noise
+   -> Double -- ^ The same as h but for color components. For most images value
+             -- equals 10 will be enough to remove colored noise and do not
+             -- distort colors
+   -> Int32  -- ^ templateWindowSize Size in pixels of the template patch that
+             -- is used to compute weights. Should be odd.
+             -- Recommended value 7 pixels
+   -> Int32  -- ^ searchWindowSize. Size in pixels of the window that is used to
+             -- compute weighted average for given pixel. Should be odd.
+             -- Affect performance linearly: greater searchWindowsSize -
+             -- greater denoising time. Recommended value 21 pixels
+   -> V.Vector (Mat ('S [h, w]) ('S 3) ('S Word8))
+             -- ^ Vector of odd number of input 8-bit 3-channel images.
+   -> CvExcept (Mat ('S [h, w]) ('S 3) ('S Word8))
+             -- ^ Output image same size and type as input.
 
-fastNlMeansDenoisingColoredMulti h hColor templateWindowSize searchWindowSize srcVec = unsafeWrapException $ do
+fastNlMeansDenoisingColoredMulti h hColor templateWindowSize searchWindowSize srcVec =
+  unsafeWrapException $ do
     dst <- newEmptyMat
     handleCvException (pure $ unsafeCoerceMat dst) $
       withArrayPtr srcVec $ \srcVecPtr      ->
       withPtr dst         $ \dstPtr         ->
       [cvExcept|
-        std::vector<Mat> buffer( $(Mat * srcVecPtr), $(Mat * srcVecPtr) + $(int32_t c'temporalWindowSize) );
+        std::vector<Mat> buffer( $(Mat * srcVecPtr)
+                    , $(Mat * srcVecPtr) + $(int32_t c'temporalWindowSize) );
         cv::fastNlMeansDenoisingColoredMulti( buffer
                                             , *$(Mat * dstPtr)
                                             , $(int32_t c'imgToDenoiseIndex)
@@ -244,3 +259,59 @@ fastNlMeansDenoisingColoredMulti h hColor templateWindowSize searchWindowSize sr
         | c'srcVecLength `mod` 2 == 1 = c'srcVecLength
         | otherwise                   = c'srcVecLength - 1
     c'imgToDenoiseIndex = (c'temporalWindowSize - 1) `div` 2
+
+{- | Preform denoise_TVL1
+
+Example:
+
+@
+
+eachChannel f img = unsafeCoerceMat . matMerge <$> V.mapM f (matSplit img)
+
+denoise_TVL1Img
+    :: forall h w w2 c d
+     . ( Mat (ShapeT [h, w]) ('S c) ('S d) ~ Lenna_512x512
+       , w2 ~ ((*) w 2)
+       )
+    => Mat ('S ['S h, 'S w2]) ('S c) ('S d)
+denoise_TVL1Img = exceptError $ do
+    denoised <- eachChannel (denoise_TVL1 2 50 . V.singleton) lenna_512x512
+    withMatM
+      (Proxy :: Proxy [h, w2])
+      (Proxy :: Proxy c)
+      (Proxy :: Proxy d)
+      black $ \imgM -> do
+        matCopyToM imgM (V2 0 0) lenna_512x512 Nothing
+        matCopyToM imgM (V2 w 0) denoised Nothing
+  where
+    w = fromInteger $ natVal (Proxy :: Proxy w)
+@
+
+<<doc/generated/examples/denoise_TVL1Img.png denoise_TVL1Img>>
+-}
+
+denoise_TVL1
+   :: Double -- ^ details more is more 2
+   -> Int32  -- ^ Number of iterations that the algorithm will run
+   -> V.Vector (Mat ('S [h, w]) ('S 1) ('S Word8))
+             -- ^ Vector of odd number of input 8-bit 3-channel images.
+   -> CvExcept (Mat ('S [h, w]) ('S 1) ('S Word8))
+             -- ^ Output image same size and type as input.
+
+denoise_TVL1 lambda niters srcVec = unsafeWrapException $ do
+    dst <- newEmptyMat
+    handleCvException (pure $ unsafeCoerceMat dst) $
+      withArrayPtr srcVec $ \srcVecPtr      ->
+      withPtr dst         $ \dstPtr         ->
+      [cvExcept|
+        std::vector<Mat> buffer( $(Mat * srcVecPtr)
+                           , $(Mat * srcVecPtr) + $(int32_t c'srcVecLength) );
+        cv::denoise_TVL1( buffer
+                        , *$(Mat * dstPtr)
+                        , $(double c'lambda)
+                        , $(int32_t niters)
+                        );
+      |]
+  where
+    c'lambda = realToFrac lambda
+    c'srcVecLength = fromIntegral $ V.length srcVec

--- a/src/OpenCV/Photo.hs
+++ b/src/OpenCV/Photo.hs
@@ -113,7 +113,7 @@ inpaint inpaintRadius method src inpaintMask = unsafeWrapException $ do
     c'method = marshalInpaintingMethod method
     c'inpaintRadius = realToFrac inpaintRadius
 
-{- | Preform fastNlMeansDenoising function for colored images. Denoising is not
+{- | Perform fastNlMeansDenoising function for colored images. Denoising is not
      per channel but in a different colour space
 
 Example:
@@ -178,7 +178,7 @@ fastNlMeansDenoisingColored h hColor templateWindowSize searchWindowSize src =
     c'h = realToFrac h
     c'hColor = realToFrac hColor
 
-{- | Preform fastNlMeansDenoisingColoredMulti function for colored images.
+{- | Perform fastNlMeansDenoisingColoredMulti function for colored images.
      Denoising is not pre channel but in a different colour space.
      This wrapper differs from the original OpenCV version by using all input
      images and denoising the middle one. The original version would allow
@@ -260,13 +260,11 @@ fastNlMeansDenoisingColoredMulti h hColor templateWindowSize searchWindowSize sr
         | otherwise                   = c'srcVecLength - 1
     c'imgToDenoiseIndex = (c'temporalWindowSize - 1) `div` 2
 
-{- | Preform denoise_TVL1
+{- | Perform denoise_TVL1
 
 Example:
 
 @
-
-eachChannel f img = unsafeCoerceMat . matMerge <$> V.mapM f (matSplit img)
 
 denoise_TVL1Img
     :: forall h w w2 c d
@@ -275,7 +273,7 @@ denoise_TVL1Img
        )
     => Mat ('S ['S h, 'S w2]) ('S c) ('S d)
 denoise_TVL1Img = exceptError $ do
-    denoised <- eachChannel (denoise_TVL1 2 50 . V.singleton) lenna_512x512
+    denoised <- matChannelMapM (denoise_TVL1 2 50 . V.singleton) lenna_512x512
     withMatM
       (Proxy :: Proxy [h, w2])
       (Proxy :: Proxy c)


### PR DESCRIPTION
Add  examples for the wrapper
wrap to 80 lines, improve comments
http://docs.opencv.org/3.1.0/d1/d79/group__photo__denoise.html