### PR TITLE
initial wrapper for WriteVideo

### DIFF
--- a/examples/src/highgui.hs
+++ b/examples/src/highgui.hs
@@ -7,4 +7,4 @@ main = do
     img <- CV.imdecode CV.ImreadUnchanged <$> B.readFile "data/Lenna.png"
     CV.withWindow "test" $ \window -> do
       CV.imshow window img
-      void $ CV.waitKey 10000
+      void $ CV.waitKey 0

--- a/examples/src/videoio-background-sub.hs
+++ b/examples/src/videoio-background-sub.hs
@@ -12,7 +12,7 @@ main = do
     cap <- CV.newVideoCapture
     -- Open the first available video capture device. Usually the
     -- webcam if run on a laptop.
-    CV.exceptErrorIO $ CV.videoCaptureOpen cap $ CV.VideoDeviceSource 0
+    CV.exceptErrorIO $ CV.videoCaptureOpen cap $ CV.VideoDeviceSource 0 Nothing
     isOpened <- CV.videoCaptureIsOpened cap
 
 --     bs <- newBackgroundSubtractorMOG2 Nothing Nothing Nothing

--- a/examples/src/videoio-noise-multi.hs
+++ b/examples/src/videoio-noise-multi.hs
@@ -13,7 +13,7 @@ main = do
     cap <- CV.newVideoCapture
     -- Open the first available video capture device. Usually the
     -- webcam if run on a laptop.
-    CV.exceptErrorIO $ CV.videoCaptureOpen cap $ CV.VideoDeviceSource 0
+    CV.exceptErrorIO $ CV.videoCaptureOpen cap $ CV.VideoDeviceSource 0 Nothing
     isOpened <- CV.videoCaptureIsOpened cap
     case isOpened of
       False -> putStrLn "Couldn't open video capture device"

--- a/examples/src/videoio.hs
+++ b/examples/src/videoio.hs
@@ -4,17 +4,25 @@
 import Control.Monad ( unless )
 import qualified OpenCV as CV
 import OpenCV.TypeLevel
+import OpenCV.VideoIO.Types
 
 main :: IO ()
 main = do
     cap <- CV.newVideoCapture
     -- Open the first available video capture device. Usually the
     -- webcam if run on a laptop.
-    CV.exceptErrorIO $ CV.videoCaptureOpen cap $ CV.VideoDeviceSource 0
+    CV.exceptErrorIO $ CV.videoCaptureOpen cap $ CV.VideoDeviceSource 0 Nothing
     isOpened <- CV.videoCaptureIsOpened cap
+
     case isOpened of
       False -> putStrLn "Couldn't open video capture device"
-      True -> CV.withWindow "video" $ \window -> do
+      True -> do
+         w <- CV.videoCaptureGetI cap VideoCapPropFrameWidth
+         h <- CV.videoCaptureGetI cap VideoCapPropFrameHeight
+
+         putStrLn $ "Video size: " ++ show w ++ " x " ++ show h
+
+         CV.withWindow "video" $ \window -> do
                 loop cap window
   where
     loop cap window = do

--- a/opencv.cabal
+++ b/opencv.cabal
@@ -57,6 +57,7 @@ library
       , src/OpenCV/Video.cpp
       , src/OpenCV/Video/MotionAnalysis.cpp
       , src/OpenCV/VideoIO/VideoCapture.cpp
+      , src/OpenCV/VideoIO/VideoWriter.cpp
 
     cc-options: -Wall -std=c++11
     ghc-options: -Wall -fwarn-incomplete-patterns -funbox-strict-fields -O2
@@ -112,7 +113,9 @@ library
         OpenCV.Unsafe
         OpenCV.Video
         OpenCV.Video.MotionAnalysis
+        OpenCV.VideoIO.Types
         OpenCV.VideoIO.VideoCapture
+        OpenCV.VideoIO.VideoWriter
 
         OpenCV.Internal
         OpenCV.Internal.Mutable

--- a/src/OpenCV/Internal/C/Inline.hs
+++ b/src/OpenCV/Internal/C/Inline.hs
@@ -115,6 +115,7 @@ openCvTypesTable = M.fromList
   , ( C.TypeName "Ptr_BackgroundSubtractorMOG2", [t| C'Ptr_BackgroundSubtractorMOG2 |] )
 
   , ( C.TypeName "VideoCapture", [t| C'VideoCapture |] )
+  , ( C.TypeName "VideoWriter" , [t| C'VideoWriter  |] )
 
   , ( C.TypeName "MouseCallback"   , [t| FunPtr C'MouseCallback    |] )
   , ( C.TypeName "TrackbarCallback", [t| FunPtr C'TrackbarCallback |] )

--- a/src/OpenCV/Internal/C/Types.hs
+++ b/src/OpenCV/Internal/C/Types.hs
@@ -118,6 +118,9 @@ data C'Ptr_BackgroundSubtractorMOG2
 -- | Haskell representation of an OpenCV @cv::VideoCapture@ object
 data C'VideoCapture
 
+-- | Haskell representation of an OpenCV @cv::VideoWriter@ object
+data C'VideoWriter
+
 -- | Callback function for mouse events
 type C'MouseCallback
    =  Int32 -- ^ One of the @cv::MouseEvenTypes@ constants.

--- a/src/OpenCV/VideoIO/Types.hsc
+++ b/src/OpenCV/VideoIO/Types.hsc
@@ -1,0 +1,296 @@
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module OpenCV.VideoIO.Types
+    ( -- VideoCodecs
+      FourCC (..)
+    , VideoCaptureProperties (..)
+    , marshalCaptureProperties
+    , VideoCaptureAPI (..)
+    , marshalVideoCaptureAPI
+    ) where
+
+
+import "base" Data.Int ( Int32 )
+import "base" Data.Word ( Word32 )
+import "base" Data.String ( IsString (..) )
+import "base" Data.List( unfoldr )
+
+import qualified "inline-c" Language.C.Inline as C
+import qualified "inline-c-cpp" Language.C.Inline.Cpp as C
+import "this" OpenCV.Internal.C.Inline ( openCvCtx )
+
+--------------------------------------------------------------------------------
+
+C.context openCvCtx
+
+C.include "opencv2/core.hpp"
+C.include "opencv2/videoio.hpp"
+C.using "namespace cv"
+
+#include <bindings.dsl.h>
+#include "opencv2/core.hpp"
+#include "opencv2/videoio.hpp"
+
+#include "namespace.hpp"
+
+--------------------------------------------------------------------------------
+-- FourCC
+--------------------------------------------------------------------------------
+
+newtype FourCC = FourCC { unFourCC :: Int32 }
+   deriving (Enum, Num)
+
+instance IsString FourCC where
+  fromString "ask" = -1
+  fromString fcc = fromIntegral (foldr (\x acc -> acc * 256 + (toEnum . fromEnum) x) 0 fcc :: Word32)
+
+instance Show FourCC where
+  show (FourCC (-1)) = "ask"
+  show (FourCC fcc) = take 4 $ unfoldr worker (fromIntegral fcc :: Word32)
+    where
+      worker 0 = Nothing
+      worker b = Just (toEnum . fromEnum $ b `mod` 256 , b `div` 256)
+
+--------------------------------------------------------------------------------
+-- VideoCaptureProperties
+-- more at https://github.com/opencv/opencv/blob/master/modules/videoio/include/opencv2/videoio.hpp
+--------------------------------------------------------------------------------
+
+data VideoCaptureProperties
+   = VideoCapPropPosMsec
+          -- ^ Current position of the video file in milliseconds.
+   | VideoCapPropPosFrames
+          -- ^ 0-based index of the frame to be decoded/captured next.
+   | VideoCapPropPosAviRatio
+          -- ^ Relative position of the video file: 0=start of the film,
+          --   1=end of the film.
+   | VideoCapPropFrameWidth     -- ^ Width of the frames in the video stream.
+   | VideoCapPropFrameHeight    -- ^ Height of the frames in the video stream.
+   | VideoCapPropFps            -- ^ Frame rate.
+   | VideoCapPropFourCc         -- ^ 4-character code of codec.
+   | VideoCapPropFrameCount     -- ^ Number of frames in the video file.
+   | VideoCapPropFormat
+          -- ^ Format of the %Mat objects returned by VideoCapture::retrieve().
+   | VideoCapPropMode
+          -- ^ Backend-specific value indicating the current capture mode.
+   | VideoCapPropBrightness     -- ^ Brightness of the image (only for cameras).
+   | VideoCapPropContrast       -- ^ Contrast of the image (only for cameras).
+   | VideoCapPropSaturation     -- ^ Saturation of the image (only for cameras).
+   | VideoCapPropHue            -- ^ Hue of the image (only for cameras).
+   | VideoCapPropGain           -- ^ Gain of the image (only for cameras).
+   | VideoCapPropExposure       -- ^ Exposure (only for cameras).
+   | VideoCapPropConvertRgb
+        -- ^ Boolean flags indicating whether images should be converted to RGB.
+   | VideoCapPropWhiteBalanceBlueU -- ^ Currently unsupported.
+   | VideoCapPropRectification
+        -- ^ Rectification flag for stereo cameras
+        --  (note: only supported by DC1394 v 2.x backend currently).
+   | VideoCapPropMonochrome        -- ^
+   | VideoCapPropSharpness         -- ^
+   | VideoCapPropAutoExposure
+        -- ^ DC1394: exposure control done by camera, user can adjust reference
+        -- level using this feature.
+   | VideoCapPropGamma             -- ^
+   | VideoCapPropTemperature       -- ^
+   | VideoCapPropTrigger           -- ^
+   | VideoCapPropTriggerDelay      -- ^
+   | VideoCapPropWhiteBalanceRedV  -- ^
+   | VideoCapPropZoom              -- ^
+   | VideoCapPropFocus             -- ^
+   | VideoCapPropGuid              -- ^
+   | VideoCapPropIsoSpeed          -- ^
+   | VideoCapPropBacklight         -- ^
+   | VideoCapPropPan               -- ^
+   | VideoCapPropTilt              -- ^
+   | VideoCapPropRoll              -- ^
+   | VideoCapPropIris              -- ^
+   | VideoCapPropSettings
+        -- ^ Pop up video/camera filter dialog (note: only supported by DSHOW
+        --  backend currently. Property value is ignored)
+   | VideoCapPropBuffersize        -- ^
+   | VideoCapPropAutofocus         -- ^
+   | VideoCapPropInt !Int32
+       -- ^ any property we need will depend on the backend
+
+
+#num CAP_PROP_POS_MSEC
+#num CAP_PROP_POS_FRAMES
+#num CAP_PROP_POS_AVI_RATIO
+#num CAP_PROP_FRAME_WIDTH
+#num CAP_PROP_FRAME_HEIGHT
+#num CAP_PROP_FPS
+#num CAP_PROP_FOURCC
+#num CAP_PROP_FRAME_COUNT
+#num CAP_PROP_FORMAT
+#num CAP_PROP_MODE
+#num CAP_PROP_BRIGHTNESS
+#num CAP_PROP_CONTRAST
+#num CAP_PROP_SATURATION
+#num CAP_PROP_HUE
+#num CAP_PROP_GAIN
+#num CAP_PROP_EXPOSURE
+#num CAP_PROP_CONVERT_RGB
+#num CAP_PROP_WHITE_BALANCE_BLUE_U
+#num CAP_PROP_RECTIFICATION
+#num CAP_PROP_MONOCHROME
+#num CAP_PROP_SHARPNESS
+#num CAP_PROP_AUTO_EXPOSURE
+#num CAP_PROP_GAMMA
+#num CAP_PROP_TEMPERATURE
+#num CAP_PROP_TRIGGER
+#num CAP_PROP_TRIGGER_DELAY
+#num CAP_PROP_WHITE_BALANCE_RED_V
+#num CAP_PROP_ZOOM
+#num CAP_PROP_FOCUS
+#num CAP_PROP_GUID
+#num CAP_PROP_ISO_SPEED
+#num CAP_PROP_BACKLIGHT
+#num CAP_PROP_PAN
+#num CAP_PROP_TILT
+#num CAP_PROP_ROLL
+#num CAP_PROP_IRIS
+#num CAP_PROP_SETTINGS
+#num CAP_PROP_BUFFERSIZE
+#num CAP_PROP_AUTOFOCUS
+
+marshalCaptureProperties :: VideoCaptureProperties -> Int32
+marshalCaptureProperties = \case
+   VideoCapPropPosMsec           -> c'CAP_PROP_POS_MSEC
+   VideoCapPropPosFrames         -> c'CAP_PROP_POS_FRAMES
+   VideoCapPropPosAviRatio       -> c'CAP_PROP_POS_AVI_RATIO
+   VideoCapPropFrameWidth        -> c'CAP_PROP_FRAME_WIDTH
+   VideoCapPropFrameHeight       -> c'CAP_PROP_FRAME_HEIGHT
+   VideoCapPropFps               -> c'CAP_PROP_FPS
+   VideoCapPropFourCc            -> c'CAP_PROP_FOURCC
+   VideoCapPropFrameCount        -> c'CAP_PROP_FRAME_COUNT
+   VideoCapPropFormat            -> c'CAP_PROP_FORMAT
+   VideoCapPropMode              -> c'CAP_PROP_MODE
+   VideoCapPropBrightness        -> c'CAP_PROP_BRIGHTNESS
+   VideoCapPropContrast          -> c'CAP_PROP_CONTRAST
+   VideoCapPropSaturation        -> c'CAP_PROP_SATURATION
+   VideoCapPropHue               -> c'CAP_PROP_HUE
+   VideoCapPropGain              -> c'CAP_PROP_GAIN
+   VideoCapPropExposure          -> c'CAP_PROP_EXPOSURE
+   VideoCapPropConvertRgb        -> c'CAP_PROP_CONVERT_RGB
+   VideoCapPropWhiteBalanceBlueU -> c'CAP_PROP_WHITE_BALANCE_BLUE_U
+   VideoCapPropRectification     -> c'CAP_PROP_RECTIFICATION
+   VideoCapPropMonochrome        -> c'CAP_PROP_MONOCHROME
+   VideoCapPropSharpness         -> c'CAP_PROP_SHARPNESS
+   VideoCapPropAutoExposure      -> c'CAP_PROP_AUTO_EXPOSURE
+   VideoCapPropGamma             -> c'CAP_PROP_GAMMA
+   VideoCapPropTemperature       -> c'CAP_PROP_TEMPERATURE
+   VideoCapPropTrigger           -> c'CAP_PROP_TRIGGER
+   VideoCapPropTriggerDelay      -> c'CAP_PROP_TRIGGER_DELAY
+   VideoCapPropWhiteBalanceRedV  -> c'CAP_PROP_WHITE_BALANCE_RED_V
+   VideoCapPropZoom              -> c'CAP_PROP_ZOOM
+   VideoCapPropFocus             -> c'CAP_PROP_FOCUS
+   VideoCapPropGuid              -> c'CAP_PROP_GUID
+   VideoCapPropIsoSpeed          -> c'CAP_PROP_ISO_SPEED
+   VideoCapPropBacklight         -> c'CAP_PROP_BACKLIGHT
+   VideoCapPropPan               -> c'CAP_PROP_PAN
+   VideoCapPropTilt              -> c'CAP_PROP_TILT
+   VideoCapPropRoll              -> c'CAP_PROP_ROLL
+   VideoCapPropIris              -> c'CAP_PROP_IRIS
+   VideoCapPropSettings          -> c'CAP_PROP_SETTINGS
+   VideoCapPropBuffersize        -> c'CAP_PROP_BUFFERSIZE
+   VideoCapPropAutofocus         -> c'CAP_PROP_AUTOFOCUS
+   VideoCapPropInt a             -> a
+
+--------------------------------------------------------------------------------
+-- VideoCaptureProperties
+-- more at https://github.com/opencv/opencv/blob/master/modules/videoio/include/opencv2/videoio.hpp
+--------------------------------------------------------------------------------
+data VideoCaptureAPI      -- ^
+   = VideoCapAny          -- ^ Auto detect == 0
+   | VideoCapVfw          -- ^ Video For Windows (platform native)
+   | VideoCapV4l          -- ^ V4L/V4L2 capturing support via libv4l
+   | VideoCapV4l2         -- ^ Same as CAP_V4L
+   | VideoCapFirewire     -- ^ IEEE 1394 drivers
+   | VideoCapFireware     -- ^ Same as CAP_FIREWIRE
+   | VideoCapIeee1394     -- ^ Same as CAP_FIREWIRE
+   | VideoCapDc1394       -- ^ Same as CAP_FIREWIRE
+   | VideoCapCmu1394      -- ^ Same as CAP_FIREWIRE
+   | VideoCapQt           -- ^ QuickTime
+   | VideoCapUnicap       -- ^ Unicap drivers
+   | VideoCapDshow        -- ^ DirectShow (via videoInput)
+   | VideoCapPvapi        -- ^ PvAPI, Prosilica GigE SDK
+   | VideoCapOpenni       -- ^ OpenNI (for Kinect)
+   | VideoCapOpenniAsus   -- ^ OpenNI (for Asus Xtion)
+   | VideoCapAndroid      -- ^ Android - not used
+   | VideoCapXiapi        -- ^ XIMEA Camera API
+   | VideoCapAvfoundation
+        -- ^ AVFoundation framework for iOS (OS X Lion will have the same API)
+   | VideoCapGiganetix    -- ^ Smartek Giganetix GigEVisionSDK
+   | VideoCapMsmf         -- ^ Microsoft Media Foundation (via videoInput)
+   | VideoCapWinrt        -- ^ Microsoft Windows Runtime using Media Foundation
+   | VideoCapIntelperc    -- ^ Intel Perceptual Computing SDK
+   | VideoCapOpenni2      -- ^ OpenNI2 (for Kinect)
+   | VideoCapOpenni2Asus
+        -- ^ OpenNI2 (for Asus Xtion and Occipital Structure sensors)
+   | VideoCapGphoto2      -- ^ gPhoto2 connection
+   | VideoCapGstreamer    -- ^ GStreamer
+   | VideoCapFfmpeg
+        -- ^ Open and record video file or stream using the FFMPEG library
+   | VideoCapImages       -- ^ Image Sequence (e.g. img_%02d.jpg)
+
+#num CAP_ANY
+#num CAP_VFW
+#num CAP_V4L
+#num CAP_V4L2
+#num CAP_FIREWIRE
+#num CAP_FIREWARE
+#num CAP_IEEE1394
+#num CAP_DC1394
+#num CAP_CMU1394
+#num CAP_QT
+#num CAP_UNICAP
+#num CAP_DSHOW
+#num CAP_PVAPI
+#num CAP_OPENNI
+#num CAP_OPENNI_ASUS
+#num CAP_ANDROID
+#num CAP_XIAPI
+#num CAP_AVFOUNDATION
+#num CAP_GIGANETIX
+#num CAP_MSMF
+#num CAP_WINRT
+#num CAP_INTELPERC
+#num CAP_OPENNI2
+#num CAP_OPENNI2_ASUS
+#num CAP_GPHOTO2
+#num CAP_GSTREAMER
+#num CAP_FFMPEG
+#num CAP_IMAGES
+
+marshalVideoCaptureAPI :: VideoCaptureAPI -> Int32
+marshalVideoCaptureAPI = \case
+   VideoCapAny           -> c'CAP_ANY
+   VideoCapVfw           -> c'CAP_VFW
+   VideoCapV4l           -> c'CAP_V4L
+   VideoCapV4l2          -> c'CAP_V4L2
+   VideoCapFirewire      -> c'CAP_FIREWIRE
+   VideoCapFireware      -> c'CAP_FIREWARE
+   VideoCapIeee1394      -> c'CAP_IEEE1394
+   VideoCapDc1394        -> c'CAP_DC1394
+   VideoCapCmu1394       -> c'CAP_CMU1394
+   VideoCapQt            -> c'CAP_QT
+   VideoCapUnicap        -> c'CAP_UNICAP
+   VideoCapDshow         -> c'CAP_DSHOW
+   VideoCapPvapi         -> c'CAP_PVAPI
+   VideoCapOpenni        -> c'CAP_OPENNI
+   VideoCapOpenniAsus    -> c'CAP_OPENNI_ASUS
+   VideoCapAndroid       -> c'CAP_ANDROID
+   VideoCapXiapi         -> c'CAP_XIAPI
+   VideoCapAvfoundation  -> c'CAP_AVFOUNDATION
+   VideoCapGiganetix     -> c'CAP_GIGANETIX
+   VideoCapMsmf          -> c'CAP_MSMF
+   VideoCapWinrt         -> c'CAP_WINRT
+   VideoCapIntelperc     -> c'CAP_INTELPERC
+   VideoCapOpenni2       -> c'CAP_OPENNI2
+   VideoCapOpenni2Asus   -> c'CAP_OPENNI2_ASUS
+   VideoCapGphoto2       -> c'CAP_GPHOTO2
+   VideoCapGstreamer     -> c'CAP_GSTREAMER
+   VideoCapFfmpeg        -> c'CAP_FFMPEG
+   VideoCapImages        -> c'CAP_IMAGES

--- a/src/OpenCV/VideoIO/VideoWriter.hs
+++ b/src/OpenCV/VideoIO/VideoWriter.hs
@@ -1,0 +1,124 @@
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module OpenCV.VideoIO.VideoWriter
+  ( VideoWriter
+  , VideoWriterSink(..)
+
+  , videoWriterOpen
+  , videoWriterRelease
+  , videoWriterIsOpened
+  , videoWriterWrite
+  ) where
+
+import "base" Data.Int ( Int32 )
+import "base" Foreign.C.String ( withCString )
+import "base" Foreign.ForeignPtr ( ForeignPtr, withForeignPtr )
+import "base" Foreign.Marshal.Utils ( toBool )
+import "linear" Linear.V2 ( V2(..) )
+import qualified "inline-c" Language.C.Inline as C
+import qualified "inline-c" Language.C.Inline.Unsafe as CU
+import qualified "inline-c-cpp" Language.C.Inline.Cpp as C
+import "this" OpenCV.Core.Types
+import "this" OpenCV.VideoIO.Types
+import "this" OpenCV.Internal
+import "this" OpenCV.Internal.Exception
+import "this" OpenCV.Internal.C.Inline ( openCvCtx )
+import "this" OpenCV.Internal.C.Types
+import "this" OpenCV.TypeLevel
+import "transformers" Control.Monad.Trans.Except ( ExceptT(ExceptT) )
+
+--------------------------------------------------------------------------------
+
+C.context openCvCtx
+
+C.include "opencv2/core.hpp"
+C.include "opencv2/videoio.hpp"
+C.using "namespace cv"
+
+--------------------------------------------------------------------------------
+
+newtype VideoWriter = VideoWriter {unVideoWriter :: ForeignPtr (C VideoWriter)}
+
+type instance C VideoWriter = C'VideoWriter
+
+instance WithPtr VideoWriter where withPtr = withForeignPtr . unVideoWriter
+
+instance FromPtr VideoWriter where
+    fromPtr = objFromPtr VideoWriter $ \ptr ->
+                [CU.exp| void { delete $(VideoWriter * ptr) }|]
+
+data VideoWriterSink
+   = VideoFileSink
+      { vfsFilePath  :: !FilePath
+      , vfsFourCC    :: !FourCC
+      , vfsFps       :: !Double
+      , vfsFrameDims :: !(Int32, Int32)
+      }
+
+{- |
+ The API might change in the future, but currently we can:
+
+ Open/create a new file:
+     wr <- CV.videoWriterOpen
+        (CV.VideoFileSink
+              "tst.MOV"
+              "avc1"
+              30
+              (3840, 2160)
+        )
+
+ Now, we can write some frames, but they need to have exactly the same size
+  as the one we have opened with:
+   CV.exceptErrorIO $ CV.videoWriterWrite wr img'
+
+ We need to close at the end or it will not finalize the file:
+   CV.exceptErrorIO $ CV.videoWriterRelease wr
+
+-}
+
+videoWriterOpen :: VideoWriterSink -> IO VideoWriter
+videoWriterOpen sink =
+    fromPtr $
+      case sink of
+        VideoFileSink {..} ->
+          withCString vfsFilePath $ \c'filePath ->
+          withPtr (toSize $ uncurry V2 vfsFrameDims) $ \frameDimsPtr   ->
+            [CU.exp|VideoWriter * {
+              new cv::VideoWriter( cv::String($(const char * c'filePath))
+                                 , $(int32_t c'fourCC)
+                                 , $(double c'fps)
+                                 , *$(Size2i * frameDimsPtr)
+                                 )
+            }|]
+          where
+            c'fps = realToFrac vfsFps
+            c'fourCC = unFourCC vfsFourCC
+
+videoWriterRelease :: VideoWriter -> CvExceptT IO ()
+videoWriterRelease videoWriter =
+    ExceptT $
+    handleCvException (pure ()) $
+    withPtr videoWriter $ \videoWriterPtr ->
+      [cvExcept|
+        $(VideoWriter * videoWriterPtr)->release();
+      |]
+
+videoWriterIsOpened :: VideoWriter -> IO Bool
+videoWriterIsOpened videoWriter =
+    fmap toBool $
+    withPtr videoWriter $ \videoWriterPtr ->
+      [CU.exp| bool {
+        $(VideoWriter * videoWriterPtr)->isOpened()
+      }|]
+
+videoWriterWrite :: VideoWriter -> Mat ('S ['D, 'D]) 'D 'D -> CvExceptT IO ()
+videoWriterWrite videoWriter frame =
+    ExceptT $
+    handleCvException (pure ()) $
+    withPtr frame $ \framePtr ->
+    withPtr videoWriter $ \videoWriterPtr ->
+        [cvExcept|
+          $(VideoWriter * videoWriterPtr)->write(*$(Mat *framePtr));
+        |]


### PR DESCRIPTION
This is WIP. If any of maintainers knows how to fix it, please do merge and fix.
Otherwise, I will be fixing according to your suggestions :)

1) VideoWriter once opened will only accept 1 size images, so maybe it can be a type level?
1a) size can be inferred
2) isColor can be inferred from the image

Maybe We should have create and open as 1 operation?
i.e. merge `newVideoWriter`  and `videoWriterOpen`?

fourCC maybe we can have some constants?
