### PR TITLE
Support for openCV contrib module  `bgsegm`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,3 +54,4 @@ cache:
   - $HOME/.stack
   - .stack-work
   - opencv-3.1.0
+  - opencv_contrib-3.1.0

--- a/include/video_motion_analysis.hpp
+++ b/include/video_motion_analysis.hpp
@@ -1,7 +1,7 @@
-#ifndef __THEA_VIDEO_MOTION_ANALYSIS_H__
-#define __THEA_VIDEO_MOTION_ANALYSIS_H__
+#ifndef __HASKELL_OPENCV_VIDEO_MOTION_ANALYSIS_H__
+#define __HASKELL_OPENCV_VIDEO_MOTION_ANALYSIS_H__
 
 typedef cv::Ptr<cv::BackgroundSubtractorKNN>  Ptr_BackgroundSubtractorKNN;
 typedef cv::Ptr<cv::BackgroundSubtractorMOG2> Ptr_BackgroundSubtractorMOG2;
 
-#endif /* __THEA_VIDEO_MOTION_ANALYSIS_H__ */
+#endif /* __HASKELL_OPENCV_VIDEO_MOTION_ANALYSIS_H__ */

--- a/include/video_motion_analysis_bgsegm.hpp
+++ b/include/video_motion_analysis_bgsegm.hpp
@@ -1,0 +1,7 @@
+#ifndef __HASKELL_OPENCV_VIDEO_MOTION_ANALYSIS_BGSEGM_H__
+#define __HASKELL_OPENCV_VIDEO_MOTION_ANALYSIS_BGSEGM_H__
+
+typedef cv::Ptr<cv::bgsegm::BackgroundSubtractorGMG> Ptr_BackgroundSubtractorGMG;
+typedef cv::Ptr<cv::bgsegm::BackgroundSubtractorMOG> Ptr_BackgroundSubtractorMOG;
+
+#endif /* __HASKELL_OPENCV_VIDEO_MOTION_ANALYSIS_BGSEGM_H__ */

--- a/opencv.cabal
+++ b/opencv.cabal
@@ -29,9 +29,18 @@ flag internal-documentation
     default: False
     manual: True
 
+flag contrib-modules
+    description: Enables contrib modules
+    default: False
+    manual: True
+
 flag contrib-module-bgsegm
     description: Enables Gaussian Mixture-based Background/Foreground Segmentation.
-    default: False
+    default: True
+    manual: True
+flag contrib-module-xphoto
+    description: Enables Additional photo processing algorithms.
+    default: True
     manual: True
 
 library
@@ -163,10 +172,15 @@ library
         OpenCV.Internal.VideoIO.Constants
         OpenCV.Internal.VideoIO.Types
 
-    if flag(contrib-module-bgsegm)
-        cpp-options:     -DENABLE_CONTRIB_MODULE_BGSEGM
-        c-sources:       src/OpenCV/Video/MotionAnalysis/Bgsegm.cpp
-        exposed-modules: OpenCV.Video.MotionAnalysis.Bgsegm
+    if flag(contrib-modules)
+        if flag(contrib-module-bgsegm)
+            cpp-options:     -DENABLE_CONTRIB_MODULE_BGSEGM
+            c-sources:       src/OpenCV/Video/MotionAnalysis/Bgsegm.cpp
+            exposed-modules: OpenCV.Video.MotionAnalysis.Bgsegm
+        if flag(contrib-module-xphoto)
+            cpp-options:     -DENABLE_CONTRIB_MODULE_XPHOTO
+            c-sources:       src/OpenCV/XPhoto.cpp
+            exposed-modules: OpenCV.XPhoto
 
     default-extensions:
         BangPatterns

--- a/opencv.cabal
+++ b/opencv.cabal
@@ -29,6 +29,11 @@ flag internal-documentation
     default: False
     manual: True
 
+flag contrib-module-bgsegm
+    description: Enables Gaussian Mixture-based Background/Foreground Segmentation.
+    default: False
+    manual: True
+
 library
     hs-source-dirs: src
     include-dirs: include
@@ -158,6 +163,11 @@ library
         OpenCV.Internal.VideoIO.Constants
         OpenCV.Internal.VideoIO.Types
 
+    if flag(contrib-module-bgsegm)
+        cpp-options:     -DENABLE_CONTRIB_MODULE_BGSEGM
+        c-sources:       src/OpenCV/Video/MotionAnalysis/Bgsegm.cpp
+        exposed-modules: OpenCV.Video.MotionAnalysis.Bgsegm
+
     default-extensions:
         BangPatterns
         DataKinds
@@ -180,6 +190,8 @@ test-suite opencv-doc-images
     type: exitcode-stdio-1.0
     hs-source-dirs: doc
     main-is: images.hs
+    other-modules: ExampleExtractor
+                   Language.Haskell.Meta.Syntax.Translate
     default-language: Haskell2010
     ghc-options: -Wall -fwarn-incomplete-patterns -threaded -funbox-strict-fields -O2 -rtsopts
     build-depends:

--- a/src/OpenCV.hs
+++ b/src/OpenCV.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-dodgy-exports #-}
+{-# language CPP #-}
 
 module OpenCV
     ( module OpenCV.Calib3d
@@ -29,6 +30,9 @@ module OpenCV
     , module OpenCV.TypeLevel
 
     , module OpenCV.JSON
+#ifdef ENABLE_CONTRIB_MODULE_XPHOTO
+    , module OpenCV.XPhoto
+#endif
     ) where
 
 import OpenCV.Calib3d
@@ -59,3 +63,7 @@ import OpenCV.VideoIO.VideoCapture
 import OpenCV.TypeLevel
 
 import OpenCV.JSON ( )
+
+#ifdef ENABLE_CONTRIB_MODULE_XPHOTO
+import OpenCV.XPhoto
+#endif

--- a/src/OpenCV/Internal/C/Inline.hs
+++ b/src/OpenCV/Internal/C/Inline.hs
@@ -120,6 +120,9 @@ openCvTypesTable = M.fromList
   , ( C.TypeName "Ptr_BackgroundSubtractorKNN" , [t| C'Ptr_BackgroundSubtractorKNN  |] )
   , ( C.TypeName "Ptr_BackgroundSubtractorMOG2", [t| C'Ptr_BackgroundSubtractorMOG2 |] )
 
+  , ( C.TypeName "Ptr_BackgroundSubtractorGMG", [t| C'Ptr_BackgroundSubtractorGMG |] )
+  , ( C.TypeName "Ptr_BackgroundSubtractorMOG", [t| C'Ptr_BackgroundSubtractorMOG |] )
+
   , ( C.TypeName "VideoCapture", [t| C'VideoCapture |] )
   , ( C.TypeName "VideoWriter" , [t| C'VideoWriter  |] )
 

--- a/src/OpenCV/Internal/C/Types.hs
+++ b/src/OpenCV/Internal/C/Types.hs
@@ -123,6 +123,13 @@ data C'Ptr_BackgroundSubtractorKNN
 -- | Haskell representation of an OpenCV @cv::Ptr<cv::BackgroundSubtractorKNN>@ object
 data C'Ptr_BackgroundSubtractorMOG2
 
+-- | Haskell representation of an OpenCV @cv::Ptr<cv::bgsegm::BackgroundSubtractorGMG>@ object
+-- requires contrib-module-bgsegm flag enabled
+data C'Ptr_BackgroundSubtractorGMG
+-- | Haskell representation of an OpenCV @cv::Ptr<cv::bgsegm::Ptr_BackgroundSubtractorMOG>@ object
+-- requires contrib-module-bgsegm flag enabled
+data C'Ptr_BackgroundSubtractorMOG
+
 -- | Haskell representation of an OpenCV @cv::VideoCapture@ object
 data C'VideoCapture
 

--- a/src/OpenCV/Video/MotionAnalysis/Bgsegm.hsc
+++ b/src/OpenCV/Video/MotionAnalysis/Bgsegm.hsc
@@ -1,0 +1,241 @@
+{-# language TemplateHaskell #-}
+{-# language QuasiQuotes #-}
+{-# language MultiParamTypeClasses #-}
+
+{- |
+  Two additional background subtraction algorithms. The OpenCV Library needs
+  to have the contrib `bgsegm` module build and the package needs to be build
+  with `contrib-module-bgsegm` flag enabled
+
+  Those algorithms does not support `getBackgroundImage` (and probably never will).
+-}
+
+module OpenCV.Video.MotionAnalysis.Bgsegm
+    ( -- * Background subtractors
+      BackgroundSubtractorGMG
+    , BackgroundSubtractorMOG
+
+    , newBackgroundSubtractorGMG
+    , newBackgroundSubtractorMOG
+    ) where
+
+import "base" Control.Exception ( mask_ )
+import "base" Data.Int
+import "base" Data.Maybe
+import "base" Foreign.ForeignPtr ( ForeignPtr, withForeignPtr )
+import "base" Foreign.Marshal.Alloc ( alloca )
+import "base" Foreign.Marshal.Utils ( toBool )
+import "base" Foreign.Storable ( peek )
+import qualified "inline-c" Language.C.Inline as C
+import qualified "inline-c" Language.C.Inline.Unsafe as CU
+import qualified "inline-c-cpp" Language.C.Inline.Cpp as C
+import "primitive" Control.Monad.Primitive
+import "this" OpenCV.Core.Types
+import "this" OpenCV.Internal
+import "this" OpenCV.Internal.C.Inline ( openCvCtx )
+import "this" OpenCV.Internal.Core.Types.Mat
+import "this" OpenCV.Internal.C.Types
+import "this" OpenCV.Video.MotionAnalysis ( BackgroundSubtractor(..) )
+
+--------------------------------------------------------------------------------
+
+C.context openCvCtx
+
+C.include "opencv2/core.hpp"
+C.include "opencv2/video.hpp"
+C.include "opencv2/bgsegm.hpp"
+C.include "video_motion_analysis_bgsegm.hpp"
+
+C.using "namespace cv"
+
+#include <bindings.dsl.h>
+#include "opencv2/core.hpp"
+#include "opencv2/video.hpp"
+#include "opencv2/bgsegm.hpp"
+
+#include "namespace.hpp"
+#include "video_motion_analysis_bgsegm.hpp"
+
+--------------------------------------------------------------------------------
+
+newtype BackgroundSubtractorGMG s
+      = BackgroundSubtractorGMG
+        { unBackgroundSubtractorGMG :: ForeignPtr C'Ptr_BackgroundSubtractorGMG }
+
+newtype BackgroundSubtractorMOG s
+      = BackgroundSubtractorMOG
+        { unBackgroundSubtractorMOG :: ForeignPtr C'Ptr_BackgroundSubtractorMOG }
+
+type instance C (BackgroundSubtractorGMG  s) = C'Ptr_BackgroundSubtractorGMG
+type instance C (BackgroundSubtractorMOG s) = C'Ptr_BackgroundSubtractorMOG
+
+instance WithPtr (BackgroundSubtractorGMG s) where
+    withPtr = withForeignPtr . unBackgroundSubtractorGMG
+
+instance WithPtr (BackgroundSubtractorMOG s) where
+    withPtr = withForeignPtr . unBackgroundSubtractorMOG
+
+instance FromPtr (BackgroundSubtractorGMG s) where
+    fromPtr = objFromPtr BackgroundSubtractorGMG $ \ptr ->
+                [CU.block| void {
+                  cv::Ptr<cv::bgsegm::BackgroundSubtractorGMG> * knn_ptr_ptr =
+                    $(Ptr_BackgroundSubtractorGMG * ptr);
+                  knn_ptr_ptr->release();
+                  delete knn_ptr_ptr;
+                }|]
+
+instance FromPtr (BackgroundSubtractorMOG s) where
+    fromPtr = objFromPtr BackgroundSubtractorMOG $ \ptr ->
+                [CU.block| void {
+                  cv::Ptr<cv::bgsegm::BackgroundSubtractorMOG> * mog2_ptr_ptr =
+                    $(Ptr_BackgroundSubtractorMOG * ptr);
+                  mog2_ptr_ptr->release();
+                  delete mog2_ptr_ptr;
+                }|]
+
+--------------------------------------------------------------------------------
+
+newBackgroundSubtractorGMG
+    :: (PrimMonad m)
+    => Maybe Int32
+       -- ^ Number of frames used to initialize the background models.
+    -> Maybe Double
+       -- ^ Threshold value, above which it is marked foreground, else background.
+    -> m (BackgroundSubtractorGMG (PrimState m))
+newBackgroundSubtractorGMG mbInitializationFrames mbDecisionThreshold =
+  unsafePrimToPrim $ fromPtr
+    [CU.block|Ptr_BackgroundSubtractorGMG * {
+      cv::Ptr<cv::bgsegm::BackgroundSubtractorGMG> gmgPtr =
+        cv::bgsegm::createBackgroundSubtractorGMG
+        ( $(int32_t c'initializationFrames)
+        , $(double  c'decisionThreshold   )
+        );
+      return new cv::Ptr<cv::bgsegm::BackgroundSubtractorGMG>(gmgPtr);
+    }|]
+  where
+    c'initializationFrames = fromMaybe 120 mbInitializationFrames
+    c'decisionThreshold    = maybe 0.8 realToFrac mbDecisionThreshold
+
+newBackgroundSubtractorMOG
+    :: (PrimMonad m)
+    => Maybe Int32
+       -- ^ Length of the history.
+    -> Maybe Int32
+       -- ^ Number of Gaussian mixtures.
+    -> Maybe Double
+       -- ^ Background ratio.
+    -> Maybe Double
+       -- ^ Noise strength (standard deviation of the brightness or each
+       --  color channel). 0 means some automatic value.
+    -> m (BackgroundSubtractorMOG (PrimState m))
+newBackgroundSubtractorMOG mbHistory mbNumGausianMix mbBackgroundRatio mbNoise
+  = unsafePrimToPrim $ fromPtr
+    [CU.block|Ptr_BackgroundSubtractorMOG * {
+      cv::Ptr<cv::bgsegm::BackgroundSubtractorMOG> mog2Ptr =
+        cv::bgsegm::createBackgroundSubtractorMOG
+        ( $(int32_t c'history       )
+        , $(int32_t c'numGausianMix )
+        , $(double  c'backgroundRatio )
+        , $(double  c'noise )
+        );
+      return new cv::Ptr<cv::bgsegm::BackgroundSubtractorMOG>(mog2Ptr);
+    }|]
+  where
+    c'history          = fromMaybe 200 mbHistory
+    c'numGausianMix    = fromMaybe 5   mbNumGausianMix
+    c'backgroundRatio  = maybe 0.7 realToFrac mbBackgroundRatio
+    c'noise            = maybe 0   realToFrac mbNoise
+
+--------------------------------------------------------------------------------
+
+instance (PrimMonad m, s ~ PrimState m) => Algorithm (BackgroundSubtractorGMG s) m where
+    algorithmClearState knn = unsafePrimToPrim $
+        withPtr knn $ \knnPtr ->
+          [C.block|void {
+              cv::bgsegm::BackgroundSubtractorGMG * knn = *$(Ptr_BackgroundSubtractorGMG * knnPtr);
+              knn->clear();
+          }|]
+
+    algorithmIsEmpty gmg = unsafePrimToPrim $
+        withPtr gmg $ \gmgPtr ->
+        alloca $ \emptyPtr -> do
+          [C.block|void {
+              cv::bgsegm::BackgroundSubtractorGMG * gmg = *$(Ptr_BackgroundSubtractorGMG * gmgPtr);
+              *$(bool * emptyPtr) = gmg->empty();
+          }|]
+          toBool <$> peek emptyPtr
+
+instance (PrimMonad m, s ~ PrimState m) => Algorithm (BackgroundSubtractorMOG s) m where
+    algorithmClearState mog2 = unsafePrimToPrim $
+        withPtr mog2 $ \mog2Ptr ->
+          [C.block|void {
+              cv::bgsegm::BackgroundSubtractorMOG * mog2 = *$(Ptr_BackgroundSubtractorMOG * mog2Ptr);
+              mog2->clear();
+          }|]
+
+    algorithmIsEmpty mog2 = unsafePrimToPrim $
+        withPtr mog2 $ \mog2Ptr ->
+        alloca $ \emptyPtr -> do
+          [C.block|void {
+              cv::bgsegm::BackgroundSubtractorMOG * mog2 = *$(Ptr_BackgroundSubtractorMOG * mog2Ptr);
+              *$(bool * emptyPtr) = mog2->empty();
+          }|]
+          toBool <$> peek emptyPtr
+
+instance (PrimMonad m, s ~ PrimState m) => BackgroundSubtractor (BackgroundSubtractorGMG s) m where
+    bgSubApply gmg learningRate img = unsafePrimToPrim $ do
+        fgMask <- newEmptyMat
+        withPtr gmg $ \gmgPtr ->
+          withPtr img $ \imgPtr ->
+          withPtr fgMask $ \fgMaskPtr -> mask_ $ do
+            [C.block| void {
+              cv::bgsegm::BackgroundSubtractorGMG * gmg = *$(Ptr_BackgroundSubtractorGMG * gmgPtr);
+              gmg->apply
+              ( *$(Mat * imgPtr)
+              , *$(Mat * fgMaskPtr)
+              , $(double c'learningRate)
+              );
+            }|]
+        pure $ unsafeCoerceMat fgMask
+      where
+        c'learningRate = realToFrac learningRate
+
+    -- not supported by the backend
+    getBackgroundImage gmg = unsafePrimToPrim $ do
+        img <- newEmptyMat
+        withPtr gmg $ \gmgPtr ->
+          withPtr img $ \imgPtr -> mask_ $ do
+            [C.block| void {
+              cv::bgsegm::BackgroundSubtractorGMG * gmg = *$(Ptr_BackgroundSubtractorGMG * gmgPtr);
+              gmg->getBackgroundImage(*$(Mat * imgPtr));
+            }|]
+            pure $ unsafeCoerceMat img
+
+instance (PrimMonad m, s ~ PrimState m) => BackgroundSubtractor (BackgroundSubtractorMOG s) m where
+    bgSubApply mog learningRate img = unsafePrimToPrim $ do
+        fgMask <- newEmptyMat
+        withPtr mog $ \mogPtr ->
+          withPtr img $ \imgPtr ->
+          withPtr fgMask $ \fgMaskPtr -> mask_ $ do
+            [C.block| void {
+              cv::bgsegm::BackgroundSubtractorMOG * mog = *$(Ptr_BackgroundSubtractorMOG * mogPtr);
+              mog->apply
+              ( *$(Mat * imgPtr)
+              , *$(Mat * fgMaskPtr)
+              , $(double c'learningRate)
+              );
+            }|]
+        pure $ unsafeCoerceMat fgMask
+      where
+        c'learningRate = realToFrac learningRate
+
+    -- not supported by the backend
+    getBackgroundImage mog = unsafePrimToPrim $ do
+        img <- newEmptyMat
+        withPtr mog $ \mogPtr ->
+          withPtr img $ \imgPtr -> mask_ $ do
+            [C.block| void {
+              cv::bgsegm::BackgroundSubtractorMOG * mog = *$(Ptr_BackgroundSubtractorMOG * mogPtr);
+              mog->getBackgroundImage(*$(Mat * imgPtr));
+            }|]
+            pure $ unsafeCoerceMat img

--- a/src/OpenCV/XPhoto.hs
+++ b/src/OpenCV/XPhoto.hs
@@ -1,0 +1,85 @@
+{-# language CPP #-}
+
+#ifndef ENABLE_CONTRIB_MODULE_XPHOTO
+{-# OPTIONS_HADDOCK hide #-}
+#endif
+
+{-# language QuasiQuotes #-}
+{-# language TemplateHaskell #-}
+
+#if __GLASGOW_HASKELL__ >= 800
+{-# options_ghc -Wno-redundant-constraints #-}
+#endif
+
+module OpenCV.XPhoto
+  ( dctDenoising
+  ) where
+
+import "base" Data.Int ( Int32 )
+import "base" Data.Word ( Word8 )
+import "base" Data.Maybe ( fromMaybe )
+import qualified "inline-c" Language.C.Inline as C
+import qualified "inline-c-cpp" Language.C.Inline.Cpp as C
+import "this" OpenCV.Internal.C.Inline ( openCvCtx )
+import "this" OpenCV.Internal.C.Types ( withPtr )
+import "this" OpenCV.Internal.Exception
+import "this" OpenCV.Internal.Core.Types.Mat
+import "this" OpenCV.TypeLevel
+
+--------------------------------------------------------------------------------
+
+C.context openCvCtx
+
+C.include "opencv2/core.hpp"
+C.include "opencv2/xphoto.hpp"
+C.using "namespace cv"
+
+{- | Perform dctDenoising function for colored images.
+
+Example:
+
+@
+dctDenoisingImg
+    :: forall h w w2 c d
+     . ( Mat (ShapeT [h, w]) ('S c) ('S d) ~ Lenna_512x512
+       , w2 ~ ((*) w 2)
+       )
+    => Mat ('S ['S h, 'S w2]) ('S c) ('S d)
+dctDenoisingImg = exceptError $ do
+    denoised <- dctDenoising 10 Nothing lenna_512x512
+    withMatM
+      (Proxy :: Proxy [h, w2])
+      (Proxy :: Proxy c)
+      (Proxy :: Proxy d)
+      black $ \imgM -> do
+        matCopyToM imgM (V2 0 0) lenna_512x512 Nothing
+        matCopyToM imgM (V2 w 0) denoised Nothing
+  where
+    w = fromInteger $ natVal (Proxy :: Proxy w)
+@
+
+<<doc/generated/examples/dctDenoisingImg.png dctDenoisingImg>>
+-}
+
+dctDenoising
+   :: Double -- ^ expected noise standard deviation
+   -> Maybe Int32  -- ^ size of block side where dct is computed use default 16
+   -> Mat ('S [h, w]) ('S 3) ('S Word8) -- ^ Input image 8-bit 3-channel image.
+   -> CvExcept (Mat ('S [h, w]) ('S 3) ('S Word8))
+             -- ^ Output image same size and type as input.
+dctDenoising sigma mPSize src =
+  unsafeWrapException $ do
+    dst <- newEmptyMat
+    handleCvException (pure $ unsafeCoerceMat dst) $
+      withPtr src         $ \srcPtr         ->
+      withPtr dst         $ \dstPtr         ->
+      [cvExcept|
+        cv::xphoto::dctDenoising( *$(Mat * srcPtr)
+                                , *$(Mat * dstPtr)
+                                , $(double c'sigma)
+                                , $(int32_t c'pSize)
+                                );
+      |]
+  where
+    c'sigma = realToFrac sigma
+    c'pSize = fromMaybe 16 mPSize

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,5 +6,7 @@ extra-deps:
 - inline-c-0.5.5.7
 - inline-c-cpp-0.1.0.0
 - repa-3.4.1.1
-flags: {}
+flags:
+  opencv:
+    contrib-module-bgsegm: true
 allow-newer: true

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,5 +8,5 @@ extra-deps:
 - repa-3.4.1.1
 flags:
   opencv:
-    contrib-module-bgsegm: true
+    contrib-modules: true
 allow-newer: true

--- a/travis-build-opencv
+++ b/travis-build-opencv
@@ -22,9 +22,15 @@ if [[ ! -d "opencv-3.1.0/build" ]]; then
   mkdir opencv-3.1.0/build
 fi
 
+if [[ ! -d "opencv_contrib-3.1.0" ]]; then
+  curl -sL https://github.com/opencv/opencv_contrib/archive/3.1.0.zip > opencv-contrib.zip
+  unzip opencv-contrib.zip
+fi
+
+
 cd opencv-3.1.0/build
 
-cmake -D WITH_IPP=OFF -D WITH_OPENGL=OFF -D WITH_QT=OFF -D BUILD_EXAMPLES=OFF -D BUILD_TESTS=OFF -D BUILD_PERF_TESTS=OFF -D CMAKE_INSTALL_PREFIX=/usr ..
+cmake -D WITH_IPP=OFF -D WITH_OPENGL=OFF -D WITH_QT=OFF -D BUILD_EXAMPLES=OFF -D BUILD_TESTS=OFF -D BUILD_PERF_TESTS=OFF -D CMAKE_INSTALL_PREFIX=/usr -DOPENCV_EXTRA_MODULES_PATH=../../opencv_contrib-3.1.0/modules ..
 make -j2
 sudo make install
 cd ../..

--- a/travis-build-opencv
+++ b/travis-build-opencv
@@ -22,7 +22,7 @@ if [[ ! -d "opencv-3.1.0/build" ]]; then
   mkdir opencv-3.1.0/build
 fi
 
-if [[ ! -d "opencv_contrib-3.1.0" ]]; then
+if [[ ! -d "opencv_contrib-3.1.0/modules" ]]; then
   curl -sL https://github.com/opencv/opencv_contrib/archive/3.1.0.zip > opencv-contrib.zip
   unzip opencv-contrib.zip
 fi
@@ -30,7 +30,9 @@ fi
 
 cd opencv-3.1.0/build
 
-cmake -D WITH_IPP=OFF -D WITH_OPENGL=OFF -D WITH_QT=OFF -D BUILD_EXAMPLES=OFF -D BUILD_TESTS=OFF -D BUILD_PERF_TESTS=OFF -D CMAKE_INSTALL_PREFIX=/usr -DOPENCV_EXTRA_MODULES_PATH=../../opencv_contrib-3.1.0/modules ..
+cmake -D WITH_IPP=OFF -D WITH_OPENGL=OFF -D WITH_QT=OFF -D BUILD_EXAMPLES=OFF -D BUILD_TESTS=OFF -D BUILD_PERF_TESTS=OFF \
+   -DBUILD_opencv_java=OFF -DBUILD_opencv_python=OFF -DBUILD_opencv_python2=OFF -DBUILD_opencv_python3=OFF\
+   -D CMAKE_INSTALL_PREFIX=/usr -DOPENCV_EXTRA_MODULES_PATH=../../opencv_contrib-3.1.0/modules ..
 make -j2
 sudo make install
 cd ../..


### PR DESCRIPTION
In order to use it, one would need to compile OpenCV with
`-DOPENCV_EXTRA_MODULES_PATH=../OpenCV-Contrib/modules ` (pointing to the right location)
Altho this is an initial implementation, just to get a feel where/ how to use flags, it implements all that module offers.
As per usual, I can fix all suggestions, but I do not mind if anyone else fixes them.