### PR TITLE
Make `opencv-examples` a library

### DIFF
--- a/examples/lib/OpenCV/Example.hs
+++ b/examples/lib/OpenCV/Example.hs
@@ -1,0 +1,60 @@
+{-# language LambdaCase #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module OpenCV.Example
+ ( createCapture
+ , createCaptureArg
+ , withEmbededFile
+ )
+where
+
+import qualified OpenCV as CV
+import System.Environment
+import System.Exit
+import System.FilePath.Posix
+
+import System.IO.Temp
+import Data.FileEmbed
+
+import Language.Haskell.TH.Syntax
+import qualified Data.ByteString as B
+
+createCapture :: String  -> IO (Maybe CV.VideoCapture)
+createCapture input = do
+    cap <- CV.newVideoCapture
+    if input `elem` ["0","1","2","3","4","5","6","7","8","9"]
+      then
+         CV.exceptErrorIO $ CV.videoCaptureOpen cap $ CV.VideoDeviceSource (read input) Nothing
+      else
+         CV.exceptErrorIO $ CV.videoCaptureOpen cap $ CV.VideoFileSource input Nothing
+    isOpened <- CV.videoCaptureIsOpened cap
+    if isOpened
+      then return $ Just cap
+      else return Nothing
+
+-- | Use first argument to the program to create capture device
+-- it should be usefull for creating demos. Numbers are for cameras and
+-- files for videos
+createCaptureArg :: IO CV.VideoCapture
+createCaptureArg =
+   getArgs >>= \case
+      []      -> createCapture "0"
+      (inp:_) -> createCapture inp
+    >>= maybe (die "could not open capture input ") return
+
+embedCallHelp :: B.ByteString -> FilePath -> (FilePath -> IO a) -> IO a
+embedCallHelp ef templ f =
+  withSystemTempFile templ $ \fn fh -> do
+       B.hPutStr fh ef
+       f fn
+
+-- | Embeder for strictly used files, it allows to embed a file, and still allow
+-- some method to use filename
+withEmbededFile :: FilePath -> Q Exp
+withEmbededFile filePath = do
+  templ <- [| $(lift $ takeFileName filePath) |]
+  ef <- embedFile filePath
+  var <- newName "f"
+  return $ LamE [VarP var] $
+    AppE (AppE ( AppE (VarE 'embedCallHelp) ef ) templ ) (VarE var)

--- a/examples/opencv-examples.cabal
+++ b/examples/opencv-examples.cabal
@@ -77,6 +77,7 @@ executable face-detect
                , opencv
                , opencv-examples
                , linear
+               , vector
                , transformers
 
   default-language: Haskell2010

--- a/examples/opencv-examples.cabal
+++ b/examples/opencv-examples.cabal
@@ -11,6 +11,19 @@ extra-source-files:
     data/*.png
     data/*.jpg
 
+library
+  default-language: Haskell2010
+  hs-source-dirs: lib
+  exposed-modules:
+    OpenCV.Example
+  build-depends: base >=4.8 && < 4.10
+               , opencv
+               , temporary
+               , bytestring
+               , filepath
+               , file-embed
+               , template-haskell
+
 executable highgui
   main-is: highgui.hs
   hs-source-dirs: src
@@ -39,6 +52,7 @@ executable videoio-noise-multi
 
   build-depends: base >=4.8 && < 4.10
                , opencv
+               , opencv-examples
                , vector
 
   default-language: Haskell2010
@@ -50,5 +64,19 @@ executable videoio-background-sub
 
   build-depends: base >=4.8 && < 4.10
                , opencv
+               , opencv-examples
+
+  default-language: Haskell2010
+
+executable face-detect
+  main-is: face-detect.hs
+  hs-source-dirs: src
+  ghc-options: -Wall -O2
+
+  build-depends: base >=4.8 && < 4.10
+               , opencv
+               , opencv-examples
+               , linear
+               , transformers
 
   default-language: Haskell2010

--- a/examples/src/face-detect.hs
+++ b/examples/src/face-detect.hs
@@ -1,12 +1,16 @@
 {-# language DataKinds #-}
 {-# language FlexibleInstances #-}
 {-# language TemplateHaskell #-}
+{-# language TupleSections #-}
+{-# language ViewPatterns #-}
+{-# language FlexibleContexts #-}
 
 import qualified OpenCV as CV
 import qualified OpenCV.Internal.Core.Types.Mat as CV
 import OpenCV.VideoIO.Types
 import GHC.Word (Word8)
 import OpenCV.Example
+import qualified Data.Vector as V
 import OpenCV.TypeLevel
 import Linear.V2 ( V2(..) )
 import Linear.V4 ( V4(..)  )
@@ -35,6 +39,8 @@ main = do
 
     minSize = Nothing :: Maybe (V2 Int32)
     maxSize = Nothing :: Maybe (V2 Int32)
+    addCorner (CV.fromRect -> CV.HRect (V2 tx ty) _) (CV.fromRect -> CV.HRect (V2 ex ey) b) =
+         CV.toRect (CV.HRect (V2 (tx + ex) (ty + ey)) b)
 
     loop cap param@(ccFrontal, ccEyes, w, h) window = do
       _ok <- CV.videoCaptureGrab cap
@@ -45,15 +51,16 @@ main = do
           let img' :: CV.Mat ('S ['D, 'D]) ('S 3) ('S Word8)
               img' = CV.exceptError $ CV.coerceMat img
               imgGray = CV.exceptError $ CV.cvtColor CV.bgr CV.gray img'
+
               faces = ccDetectMultiscale ccFrontal imgGray
-              -- eyes have to be on the face ! fix
-              eyes = ccDetectMultiscale ccEyes     imgGray
-          print faces
+              eyedFaces = V.concat . V.toList . CV.exceptError
+                $ mapM (\f -> V.map (addCorner f) . ccDetectMultiscale ccEyes
+                <$> CV.matSubRect imgGray f) faces
 
           let box = CV.exceptError $
                 CV.withMatM (h ::: w ::: Z) (Proxy :: Proxy 3) (Proxy :: Proxy Word8) white $ \imgM -> do
                   void $ CV.matCopyToM imgM (V2 0 0) (CV.unsafeCoerceMat img) Nothing
-                  forM_ eyes  $ \eyeRect  -> lift $ CV.rectangle imgM eyeRect green 2 CV.LineType_8 0
+                  forM_ eyedFaces $ \eyeRect  -> lift $ CV.rectangle imgM eyeRect green 2 CV.LineType_8 0
                   forM_ faces $ \faceRect -> lift $ CV.rectangle imgM faceRect blue 2 CV.LineType_8 0
           CV.imshow window ( CV.unsafeCoerceMat box )
 

--- a/examples/src/face-detect.hs
+++ b/examples/src/face-detect.hs
@@ -1,0 +1,65 @@
+{-# language DataKinds #-}
+{-# language FlexibleInstances #-}
+{-# language TemplateHaskell #-}
+
+import qualified OpenCV as CV
+import qualified OpenCV.Internal.Core.Types.Mat as CV
+import OpenCV.VideoIO.Types
+import GHC.Word (Word8)
+import OpenCV.Example
+import OpenCV.TypeLevel
+import Linear.V2 ( V2(..) )
+import Linear.V4 ( V4(..)  )
+import Data.Int
+import GHC.TypeLits ()
+import Data.Proxy
+import Control.Monad
+import Control.Monad.Trans.Class
+
+
+green,blue ,white:: CV.Scalar
+green  = CV.toScalar (V4   0 255   0 255 :: V4 Double)
+blue   = CV.toScalar (V4 255   0   0 255 :: V4 Double)
+white  = CV.toScalar (V4 255 255 255 255 :: V4 Double)
+
+main :: IO ()
+main = do
+    cap <- createCaptureArg
+    Just ccFrontal <- $(withEmbededFile "../data/haarcascade_frontalface_default.xml") CV.newCascadeClassifier
+    Just ccEyes    <- $(withEmbededFile "../data/haarcascade_eye.xml") CV.newCascadeClassifier
+    w <- CV.videoCaptureGetI cap VideoCapPropFrameWidth
+    h <- CV.videoCaptureGetI cap VideoCapPropFrameHeight
+    CV.withWindow "video" $ loop cap (ccFrontal, ccEyes, w, h)
+  where
+    ccDetectMultiscale cc = CV.cascadeClassifierDetectMultiScale cc Nothing Nothing minSize maxSize
+
+    minSize = Nothing :: Maybe (V2 Int32)
+    maxSize = Nothing :: Maybe (V2 Int32)
+
+    loop cap param@(ccFrontal, ccEyes, w, h) window = do
+      _ok <- CV.videoCaptureGrab cap
+      mbImg <- CV.videoCaptureRetrieve cap
+      case mbImg of
+        Just img -> do
+          -- Assert that the retrieved frame is 2-dimensional.
+          let img' :: CV.Mat ('S ['D, 'D]) ('S 3) ('S Word8)
+              img' = CV.exceptError $ CV.coerceMat img
+              imgGray = CV.exceptError $ CV.cvtColor CV.bgr CV.gray img'
+              faces = ccDetectMultiscale ccFrontal imgGray
+              -- eyes have to be on the face ! fix
+              eyes = ccDetectMultiscale ccEyes     imgGray
+          print faces
+
+          let box = CV.exceptError $
+                CV.withMatM (h ::: w ::: Z) (Proxy :: Proxy 3) (Proxy :: Proxy Word8) white $ \imgM -> do
+                  void $ CV.matCopyToM imgM (V2 0 0) (CV.unsafeCoerceMat img) Nothing
+                  forM_ eyes  $ \eyeRect  -> lift $ CV.rectangle imgM eyeRect green 2 CV.LineType_8 0
+                  forM_ faces $ \faceRect -> lift $ CV.rectangle imgM faceRect blue 2 CV.LineType_8 0
+          CV.imshow window ( CV.unsafeCoerceMat box )
+
+          key <- CV.waitKey 20
+          -- Loop unless the escape key is pressed.
+          unless (key == 27) $ loop cap param window
+
+        -- Out of frames, stop looping.
+        Nothing -> pure ()

--- a/examples/src/videoio-background-sub.hs
+++ b/examples/src/videoio-background-sub.hs
@@ -6,24 +6,17 @@ import Control.Monad ( unless )
 import qualified OpenCV as CV
 import OpenCV.TypeLevel
 import OpenCV.Video.MotionAnalysis
+import OpenCV.Example
 
 main :: IO ()
 main = do
-    cap <- CV.newVideoCapture
-    -- Open the first available video capture device. Usually the
-    -- webcam if run on a laptop.
-    CV.exceptErrorIO $ CV.videoCaptureOpen cap $ CV.VideoDeviceSource 0 Nothing
-    isOpened <- CV.videoCaptureIsOpened cap
+    cap <- createCaptureArg
+    bs <- newBackgroundSubtractorMOG2 Nothing Nothing Nothing
+--     bs <- newBackgroundSubtractorKNN Nothing Nothing Nothing
 
---     bs <- newBackgroundSubtractorMOG2 Nothing Nothing Nothing
-    bs <- newBackgroundSubtractorKNN Nothing Nothing Nothing
-
-    case isOpened of
-      False -> putStrLn "Couldn't open video capture device"
-      True -> CV.withWindow "video" $ \window -> do
-                loop cap window bs
+    CV.withWindow "video" $ loop cap bs
   where
-    loop cap window bs = do
+    loop cap bs window = do
       _ok <- CV.videoCaptureGrab cap
       mbImg <- CV.videoCaptureRetrieve cap
       case mbImg of
@@ -37,6 +30,6 @@ main = do
 
           key <- CV.waitKey 20
           -- Loop unless the escape key is pressed.
-          unless (key == 27) $ loop cap window bs
+          unless (key == 27) $ loop cap bs window
         -- Out of frames, stop looping.
         Nothing -> pure ()

--- a/examples/src/videoio-noise-multi.hs
+++ b/examples/src/videoio-noise-multi.hs
@@ -7,21 +7,15 @@ import OpenCV.TypeLevel
 import OpenCV.Photo
 import GHC.Word (Word8)
 import qualified Data.Vector as V
+import OpenCV.Example
 
 main :: IO ()
 main = do
-    cap <- CV.newVideoCapture
-    -- Open the first available video capture device. Usually the
-    -- webcam if run on a laptop.
-    CV.exceptErrorIO $ CV.videoCaptureOpen cap $ CV.VideoDeviceSource 0 Nothing
-    isOpened <- CV.videoCaptureIsOpened cap
-    case isOpened of
-      False -> putStrLn "Couldn't open video capture device"
-      True -> CV.withWindow "video" $ \window -> do
-                loop cap window V.empty
+    cap <- createCaptureArg
+    CV.withWindow "video" $ loop cap V.empty
   where
     wind = 11
-    loop cap window vect = do
+    loop cap vect window = do
       _ok <- CV.videoCaptureGrab cap
       mbImg <- CV.videoCaptureRetrieve cap
       case mbImg of
@@ -35,6 +29,6 @@ main = do
 
           key <- CV.waitKey 20
           -- Loop unless the escape key is pressed.
-          unless (key == 27) $ loop cap window vect'
+          unless (key == 27) $ loop cap vect' window
         -- Out of frames, stop looping.
         Nothing -> pure ()


### PR DESCRIPTION
Refactor some examples.
add face-detect example
add file embedded ( to allow running executables far away from the data); I might make it a library(?)

I put it in the examples package, but It could live in the main one as well.
The idea is to allow prototype/test quicker.
now we can run `face-detect` with optional `0` or `1` or `filename` and have it use that as input.
