### PR TITLE
Video decolor example

### DIFF
--- a/examples/opencv-examples.cabal
+++ b/examples/opencv-examples.cabal
@@ -58,6 +58,17 @@ executable videoio-noise-multi
 
   default-language: Haskell2010
 
+executable videoio-decolor
+  main-is: videoio-decolor.hs
+  hs-source-dirs: src
+  ghc-options: -Wall -O2
+
+  build-depends: base >=4.8 && < 4.10
+               , opencv
+               , opencv-examples
+
+  default-language: Haskell2010
+
 executable videoio-background-sub
   main-is: videoio-background-sub.hs
   hs-source-dirs: src

--- a/examples/src/videoio-decolor.hs
+++ b/examples/src/videoio-decolor.hs
@@ -1,0 +1,34 @@
+{-# language DataKinds #-}
+{-# language FlexibleInstances #-}
+
+import Control.Monad ( unless )
+import qualified OpenCV as CV
+import OpenCV.TypeLevel
+import OpenCV.Photo
+import GHC.Word (Word8)
+import OpenCV.Example
+
+main :: IO ()
+main = do
+    cap <- createCaptureArg
+    CV.withWindow "gray" $ \w1 -> CV.withWindow "boost" $ loop cap w1
+  where
+    loop cap grayWindow boostWindow = do
+      _ok <- CV.videoCaptureGrab cap
+      mbImg <- CV.videoCaptureRetrieve cap
+      case mbImg of
+        Just img -> do
+          -- Assert that the retrieved frame is 2-dimensional.
+          let img' :: CV.Mat ('S ['D, 'D]) ('S 3) ('S Word8)
+              img' = CV.exceptError $ CV.coerceMat img
+
+          let (grayImg, boostImg) = CV.exceptError $ decolor img'
+
+          CV.imshow grayWindow grayImg
+          CV.imshow boostWindow boostImg
+
+          key <- CV.waitKey 20
+          -- Loop unless the escape key is pressed.
+          unless (key == 27) $ loop cap grayWindow boostWindow
+        -- Out of frames, stop looping.
+        Nothing -> pure ()


### PR DESCRIPTION
Example usage of `decolor` on video. Opens up two windows. One with grayscale and one with color boosted video.