### PR TITLE
Use ghc-options: -optc-std=c++11

### DIFF
--- a/opencv-extra/opencv-extra.cabal
+++ b/opencv-extra/opencv-extra.cabal
@@ -74,7 +74,7 @@ library
         , inline-c-cpp >= 0.2.1
 
     cc-options: -Wall -std=c++11
-    ghc-options: -Wall -fwarn-incomplete-patterns -funbox-strict-fields
+    ghc-options: -Wall -fwarn-incomplete-patterns -funbox-strict-fields -optc-std=c++11
     if flag(internal-documentation)
         cpp-options: -DENABLE_INTERNAL_DOCUMENTATION
 

--- a/opencv/opencv.cabal
+++ b/opencv/opencv.cabal
@@ -106,7 +106,7 @@ library
         , inline-c-cpp >= 0.2.1
 
     cc-options: -Wall -std=c++11
-    ghc-options: -Wall -fwarn-incomplete-patterns -funbox-strict-fields
+    ghc-options: -Wall -fwarn-incomplete-patterns -funbox-strict-fields -optc-std=c++11
     if flag(internal-documentation)
         cpp-options: -DENABLE_INTERNAL_DOCUMENTATION
 


### PR DESCRIPTION
Fixes #104 

Mad props to `nh2[m]` in [`#haskell`](http://tunes.org/~nef/logs/haskell/18.01.21):
> 18:01:31 <nh2[m]> dukedave: in my project I use 2 entries in the .cabal file: `cc-options: 
 std=c++14`, AND `ghc-options: -optc-std=c++14`

🎉 