### PR TITLE
Replace CvExcept with MonadError

### DIFF
--- a/doc/images.hs
+++ b/doc/images.hs
@@ -194,7 +194,7 @@ loadAnimation delay fp = do
           case mbFrameRaw of
             Nothing -> pure $ reverse frames
             Just frameRaw -> do
-              frame <- exceptErrorIO $ pureExcept $ coerceMat frameRaw
+              frame <- exceptErrorIO $ coerceMat frameRaw
               grabFrames cap (frame : frames)
         else pure $ reverse frames
 

--- a/opencv-extra/opencv-extra.cabal
+++ b/opencv-extra/opencv-extra.cabal
@@ -86,6 +86,7 @@ library
       , bytestring        >= 0.10.6
       , containers        >= 0.5.6.2
       , linear            >= 1.20.4
+      , mtl
       , opencv            >= 0.0.0.0
       , primitive         >= 0.6.1
       , template-haskell  >= 2.10

--- a/opencv-extra/opencv-extra.nix
+++ b/opencv-extra/opencv-extra.nix
@@ -14,6 +14,7 @@
 , data-default
 , inline-c
 , inline-c-cpp
+, mtl
 , opencv
 , primitive
 , template-haskell
@@ -55,6 +56,7 @@ mkDerivation {
     containers
     inline-c
     inline-c-cpp
+    mtl
     opencv
     primitive
     template-haskell

--- a/opencv-extra/src/OpenCV/Extra/ArUco.hsc
+++ b/opencv-extra/src/OpenCV/Extra/ArUco.hsc
@@ -44,6 +44,7 @@ import "base" System.IO.Unsafe
 import qualified "inline-c" Language.C.Inline as C
 import qualified "inline-c-cpp" Language.C.Inline.Cpp as C
 import "linear" Linear
+import "mtl" Control.Monad.Error.Class ( MonadError )
 import "opencv" OpenCV
 import "opencv" OpenCV.Core.Types.Vec (Vec3d)
 import "opencv" OpenCV.Internal
@@ -267,11 +268,12 @@ drawEstimatedPose cameraMatrix distCoeffs (rvec, tvec) image = unsafePrimToPrim 
 camera calibration.
 -}
 calibrateCameraFromFrames
-    :: CharucoBoard
+    :: (MonadError CvException m)
+    => CharucoBoard
     -> Int
     -> Int
     -> [(ArUcoMarkers, CharucoMarkers)]
-    -> CvExcept (Matx33d, Matx51d)
+    -> m (Matx33d, Matx51d)
 calibrateCameraFromFrames board width height frames = unsafeWrapException $ do
     cameraMatrix <- newMatx33d 0 0 0 0 0 0 0 0 0
     distCoeffs <- newMatx51d 0 0 0 0 0

--- a/opencv-extra/src/OpenCV/Extra/XFeatures2d.hs
+++ b/opencv-extra/src/OpenCV/Extra/XFeatures2d.hs
@@ -25,6 +25,7 @@ import "base" System.IO.Unsafe ( unsafePerformIO )
 import qualified "inline-c" Language.C.Inline as C
 import qualified "inline-c" Language.C.Inline.Unsafe as CU
 import qualified "inline-c-cpp" Language.C.Inline.Cpp as C
+import "mtl" Control.Monad.Error.Class ( MonadError )
 import "opencv" OpenCV.Core.Types
 import "opencv" OpenCV.Internal
 import "opencv" OpenCV.Internal.C.FinalizerTH
@@ -147,12 +148,11 @@ surfDetectAndComputeImg = exceptError $ do
 <<doc/generated/examples/surfDetectAndComputeImg.png surfDetectAndComputeImg>>
 -}
 surfDetectAndCompute
-    :: Surf
+    :: (MonadError CvException m)
+    => Surf
     -> Mat ('S [height, width]) channels depth -- ^ Image.
     -> Maybe (Mat ('S [height, width]) ('S 1) ('S Word8)) -- ^ Mask.
-    -> CvExcept ( V.Vector KeyPoint
-                , Mat 'D 'D 'D
-                )
+    -> m (V.Vector KeyPoint, Mat 'D 'D 'D)
 surfDetectAndCompute surf img mbMask = unsafeWrapException $ do
     descriptors <- newEmptyMat
     withPtr surf $ \surfPtr ->

--- a/opencv-extra/src/OpenCV/Extra/XImgProc.hs
+++ b/opencv-extra/src/OpenCV/Extra/XImgProc.hs
@@ -11,6 +11,7 @@ import "base" Data.Int
 import "base" Data.Word
 import qualified "inline-c" Language.C.Inline as C
 import qualified "inline-c-cpp" Language.C.Inline.Cpp as C
+import "mtl" Control.Monad.Error.Class ( MonadError )
 import "opencv" OpenCV.Core.Types
 import "opencv" OpenCV.Internal.Core.Types.Mat
 import "opencv" OpenCV.Internal.C.Types
@@ -62,13 +63,14 @@ anisotropicDiffusionImg = exceptError $ anisotropicDiffusion 1.0 0.02 10 birds_7
 <<doc/generated/examples/anisotropicDiffusionImg.png anisotropicDiffusionImg>>
 -}
 anisotropicDiffusion
-    :: Float
+    :: (MonadError CvException m)
+    => Float
        -- ^ The amount of time to step forward by on each iteration (normally,
        -- it's between 0 and 1). Must be > 0.
     -> Float -- ^ Sensitivity to the edges. Must be /= 0.
     -> Int32 -- ^ The number of iterations. Must be >= 0.
     -> Mat ('S '[h, w]) ('S 3) ('S Word8)
-    -> CvExcept (Mat ('S '[h, w]) ('S 3) ('S Word8))
+    -> m (Mat ('S '[h, w]) ('S 3) ('S Word8))
 anisotropicDiffusion alpha k niters src = unsafeWrapException $ do
     dst <- newEmptyMat
     handleCvException (pure $ unsafeCoerceMat dst) $
@@ -130,7 +132,8 @@ codexLeicesterSAUVOLA = niBlackThresholdExample Binarization_SAUVOLA
 <<doc/generated/examples/codexLeicesterSAUVOLA.png codexLeicesterSAUVOLA>>
 -}
 niBlackThreshold
-    :: ThreshType
+    :: (MonadError CvException m)
+    => ThreshType
     -> Int32
        -- ^ Size of a pixel neighborhood that is used to calculate a
        -- threshold value for the pixel. Must be odd and >= 1.
@@ -142,7 +145,7 @@ niBlackThreshold
        -- subtracted from the mean.
     -> BinarizationMethod -- ^ Binarization method to use.
     -> Mat ('S '[h, w]) ('S 1) ('S Word8) -- ^ Source image.
-    -> CvExcept (Mat ('S '[h, w]) ('S 1) ('S Word8))
+    -> m (Mat ('S '[h, w]) ('S 1) ('S Word8))
 niBlackThreshold threshType blockSize k binarizationMethod src = unsafeWrapException $ do
     dst <- newEmptyMat
     handleCvException (pure $ unsafeCoerceMat dst) $

--- a/opencv-extra/src/OpenCV/Extra/XPhoto.hs
+++ b/opencv-extra/src/OpenCV/Extra/XPhoto.hs
@@ -15,6 +15,7 @@ import "base" Data.Word ( Word8 )
 import "base" Data.Maybe ( fromMaybe )
 import qualified "inline-c" Language.C.Inline as C
 import qualified "inline-c-cpp" Language.C.Inline.Cpp as C
+import "mtl" Control.Monad.Error.Class ( MonadError )
 import "opencv" OpenCV.Internal.C.Inline ( openCvCtx )
 import "opencv" OpenCV.Internal.C.Types ( withPtr )
 import "opencv" OpenCV.Internal.Exception
@@ -57,10 +58,11 @@ dctDenoisingImg = exceptError $ do
 -}
 
 dctDenoising
-   :: Double -- ^ expected noise standard deviation
+   :: (MonadError CvException m)
+   => Double -- ^ expected noise standard deviation
    -> Maybe Int32  -- ^ size of block side where dct is computed use default 16
    -> Mat ('S [h, w]) ('S 3) ('S Word8) -- ^ Input image 8-bit 3-channel image.
-   -> CvExcept (Mat ('S [h, w]) ('S 3) ('S Word8))
+   -> m (Mat ('S [h, w]) ('S 3) ('S Word8))
              -- ^ Output image same size and type as input.
 dctDenoising sigma mPSize src =
   unsafeWrapException $ do

--- a/opencv/opencv.cabal
+++ b/opencv/opencv.cabal
@@ -129,6 +129,7 @@ library
       , text              >= 1.2.2.1
       , transformers      >= 0.4.2
       , vector            >= 0.11
+      , mtl
 
     exposed-modules:
         OpenCV

--- a/opencv/opencv.nix
+++ b/opencv/opencv.nix
@@ -19,6 +19,7 @@
 , inline-c-cpp
 , JuicyPixels
 , linear
+, mtl
 , primitive
 , repa
 , template-haskell
@@ -78,6 +79,7 @@ mkDerivation ({
     inline-c-cpp
     JuicyPixels
     linear
+    mtl
     primitive
     repa
     template-haskell

--- a/opencv/src/OpenCV/Core/ArrayOps.hs
+++ b/opencv/src/OpenCV/Core/ArrayOps.hs
@@ -67,6 +67,7 @@ import qualified "inline-c" Language.C.Inline as C
 import qualified "inline-c-cpp" Language.C.Inline.Cpp as C
 import "linear" Linear.Vector ( zero )
 import "linear" Linear.V2 ( V2(..) )
+import "mtl" Control.Monad.Error.Class ( MonadError )
 import "primitive" Control.Monad.Primitive ( PrimMonad, PrimState, unsafePrimToPrim )
 import "this" OpenCV.Core.Types.Mat
 import "this" OpenCV.Core.Types.Point
@@ -78,7 +79,6 @@ import "this" OpenCV.Internal.Core.Types.Mat
 import "this" OpenCV.Internal.Exception
 import "this" OpenCV.Internal.Mutable
 import "this" OpenCV.TypeLevel
-import "transformers" Control.Monad.Trans.Except
 import qualified "vector" Data.Vector as V
 
 --------------------------------------------------------------------------------
@@ -163,9 +163,10 @@ matAbsDiffImg = exceptError $ matAbsDiff flower_512x341 sailboat_512x341
 <http://docs.opencv.org/3.0-last-rst/modules/core/doc/operations_on_arrays.html#absdiff OpenCV Sphinx doc>
 -}
 matAbsDiff
-    :: Mat shape channels depth -- ^
+    :: MonadError CvException m
+    => Mat shape channels depth -- ^
     -> Mat shape channels depth
-    -> CvExcept (Mat shape channels depth)
+    -> m (Mat shape channels depth)
 matAbsDiff src1 src2 = unsafeWrapException $ do
     dst <- newEmptyMat
     handleCvException (pure $ unsafeCoerceMat dst) $
@@ -194,9 +195,10 @@ matAddImg = exceptError $ matAdd flower_512x341 sailboat_512x341
 -}
 -- TODO (RvD): handle different depths
 matAdd
-    :: Mat shape channels depth -- ^
+    :: MonadError CvException m
+    => Mat shape channels depth -- ^
     -> Mat shape channels depth
-    -> CvExcept (Mat shape channels depth)
+    -> m (Mat shape channels depth)
 matAdd src1 src2 = unsafeWrapException $ do
     dst <- newEmptyMat
     handleCvException (pure $ unsafeCoerceMat dst) $
@@ -227,9 +229,10 @@ matSubtractImg = exceptError $ matSubtract flower_512x341 sailboat_512x341
 -}
 -- TODO (RvD): handle different depths
 matSubtract
-    :: Mat shape channels depth -- ^
+    :: MonadError CvException m
+    => Mat shape channels depth -- ^
     -> Mat shape channels depth
-    -> CvExcept (Mat shape channels depth)
+    -> m (Mat shape channels depth)
 matSubtract src1 src2 = unsafeWrapException $ do
     dst <- newEmptyMat
     handleCvException (pure $ unsafeCoerceMat dst) $
@@ -251,9 +254,10 @@ matSubtract src1 src2 = unsafeWrapException $ do
 -}
 -- TODO (RvD): handle different depths
 matMultiply
-    :: Mat shape channels depth -- ^
+    :: MonadError CvException m
+    => Mat shape channels depth -- ^
     -> Mat shape channels depth
-    -> CvExcept (Mat shape channels depth)
+    -> m (Mat shape channels depth)
 matMultiply src1 src2 = unsafeWrapException $ do
     dst <- newEmptyMat
     handleCvException (pure $ unsafeCoerceMat dst) $
@@ -285,14 +289,14 @@ matAddWeightedImg = exceptError $
 
 -- TODO (RvD): handle different depths
 matAddWeighted
-    :: forall shape channels srcDepth dstDepth
-     . (ToDepthDS (Proxy dstDepth))
+    :: forall shape channels srcDepth dstDepth m
+     . (ToDepthDS (Proxy dstDepth), MonadError CvException m)
     => Mat shape channels srcDepth -- ^ src1
     -> Double -- ^ alpha
     -> Mat shape channels srcDepth -- ^ src2
     -> Double -- ^ beta
     -> Double -- ^ gamma
-    -> CvExcept (Mat shape channels dstDepth)
+    -> m (Mat shape channels dstDepth)
 matAddWeighted src1 alpha src2 beta gamma = unsafeWrapException $ do
     dst <- newEmptyMat
     handleCvException (pure $ unsafeCoerceMat dst) $
@@ -325,13 +329,14 @@ array and another array.
 <http://docs.opencv.org/3.0-last-rst/modules/core/doc/operations_on_arrays.html#scaleadd OpenCV Sphinx doc>
 -}
 matScaleAdd
-    :: Mat shape channels depth
+    :: MonadError CvException m
+    => Mat shape channels depth
        -- ^ First input array.
     -> Double
        -- ^ Scale factor for the first array.
     -> Mat shape channels depth
        -- ^ Second input array.
-    -> CvExcept (Mat shape channels depth)
+    -> m (Mat shape channels depth)
 matScaleAdd src1 scale src2 = unsafeWrapException $ do
     dst <- newEmptyMat
     handleCvException (pure $ unsafeCoerceMat dst) $
@@ -350,9 +355,10 @@ matScaleAdd src1 scale src2 = unsafeWrapException $ do
     c'scale = realToFrac scale
 
 matMax
-    :: Mat shape channels depth -- ^
+    :: MonadError CvException m
+    => Mat shape channels depth -- ^
     -> Mat shape channels depth
-    -> CvExcept (Mat shape channels depth)
+    -> m (Mat shape channels depth)
 matMax src1 src2 = unsafeWrapException $ do
     dst <- newEmptyMat
     handleCvException (pure $ unsafeCoerceMat dst) $
@@ -369,10 +375,11 @@ matMax src1 src2 = unsafeWrapException $ do
 
 -- | Performs a per-element comparison of an array and a scalar value.
 matScalarCompare
-    :: Mat shape ('S 1) depth -- ^
+    :: MonadError CvException m
+    => Mat shape ('S 1) depth -- ^
     -> Double
     -> CmpType
-    -> CvExcept (Mat shape ('S 1) ('S Word8))
+    -> m (Mat shape ('S 1) ('S Word8))
 matScalarCompare src x cmpType = unsafeWrapException $ do
     dst <- newEmptyMat
     handleCvException (pure $ unsafeCoerceMat dst) $
@@ -392,10 +399,11 @@ matScalarCompare src x cmpType = unsafeWrapException $ do
 
 -- | Performs a per-element comparison of two matrices.
 matCompare
-    :: Mat shape ('S 1) depth
+    :: MonadError CvException m
+    => Mat shape ('S 1) depth
     -> Mat shape ('S 1) depth
     -> CmpType
-    -> CvExcept (Mat shape ('S 1) ('S Word8))
+    -> m (Mat shape ('S 1) ('S Word8))
 matCompare x y cmpType = unsafeWrapException $ do
     dst <- newEmptyMat
     handleCvException (pure $ unsafeCoerceMat dst) $
@@ -467,8 +475,9 @@ bitwiseNotImg = exceptError $ do
 <http://docs.opencv.org/3.0-last-rst/modules/core/doc/operations_on_arrays.html#bitwise-not OpenCV Sphinx doc>
 -}
 bitwiseNot
-    :: Mat shape channels depth -- ^
-    -> CvExcept (Mat shape channels depth)
+    :: MonadError CvException m
+    => Mat shape channels depth -- ^
+    -> m (Mat shape channels depth)
 bitwiseNot src = unsafeWrapException $ do
     dst <- newEmptyMat
     handleCvException (pure $ unsafeCoerceMat dst) $
@@ -503,9 +512,10 @@ bitwiseAndImg = exceptError $ do
 <http://docs.opencv.org/3.0-last-rst/modules/core/doc/operations_on_arrays.html#bitwise-and OpenCV Sphinx doc>
 -}
 bitwiseAnd
-    :: Mat shape channels depth -- ^
+    :: MonadError CvException m
+    => Mat shape channels depth -- ^
     -> Mat shape channels depth
-    -> CvExcept (Mat shape channels depth)
+    -> m (Mat shape channels depth)
 bitwiseAnd src1 src2 = unsafeWrapException $ do
     dst <- newEmptyMat
     handleCvException (pure $ unsafeCoerceMat dst) $
@@ -542,9 +552,10 @@ bitwiseOrImg = exceptError $ do
 <http://docs.opencv.org/3.0-last-rst/modules/core/doc/operations_on_arrays.html#bitwise-or OpenCV Sphinx doc>
 -}
 bitwiseOr
-    :: Mat shape channels depth -- ^
+    :: MonadError CvException m
+    => Mat shape channels depth -- ^
     -> Mat shape channels depth
-    -> CvExcept (Mat shape channels depth)
+    -> m (Mat shape channels depth)
 bitwiseOr src1 src2 = unsafeWrapException $ do
     dst <- newEmptyMat
     handleCvException (pure $ unsafeCoerceMat dst) $
@@ -581,9 +592,10 @@ bitwiseXorImg = exceptError $ do
 <http://docs.opencv.org/3.0-last-rst/modules/core/doc/operations_on_arrays.html#bitwise-xor OpenCV Sphinx doc>
 -}
 bitwiseXor
-    :: Mat shape channels depth -- ^
+    :: MonadError CvException m
+    => Mat shape channels depth -- ^
     -> Mat shape channels depth
-    -> CvExcept (Mat shape channels depth)
+    -> m (Mat shape channels depth)
 bitwiseXor src1 src2 = unsafeWrapException $ do
     dst <- newEmptyMat
     handleCvException (pure $ unsafeCoerceMat dst) $
@@ -701,8 +713,9 @@ matChannelMapM f img = unsafeCoerceMat . matMerge <$> V.mapM f (matSplit img)
 -}
 -- TODO (RvD): implement mask
 minMaxLoc
-    :: Mat ('S [height, width]) channels depth -- ^
-    -> CvExcept (Double, Double, Point2i, Point2i)
+    :: MonadError CvException m
+    => Mat ('S [height, width]) channels depth -- ^
+    -> m (Double, Double, Point2i, Point2i)
 minMaxLoc src = unsafeWrapException $ do
     minLoc <- toPointIO $ V2 0 0
     maxLoc <- toPointIO $ V2 0 0
@@ -730,12 +743,13 @@ minMaxLoc src = unsafeWrapException $ do
 <http://docs.opencv.org/3.0-last-rst/modules/core/doc/operations_on_arrays.html#norm OpenCV Sphinx doc>
 -}
 norm
-    :: NormType
+    :: MonadError CvException m
+    => NormType
     -> Maybe (Mat shape ('S 1) ('S Word8))
        -- ^ Optional operation mask; it must have the same size as the input
        -- array, depth 'Depth_8U' and 1 channel.
     -> Mat shape channels depth -- ^ Input array.
-    -> CvExcept Double  -- ^ Calculated norm.
+    -> m Double  -- ^ Calculated norm.
 norm normType mbMask src = unsafeWrapException $
     withPtr src    $ \srcPtr  ->
     withPtr mbMask $ \mskPtr  ->
@@ -757,14 +771,15 @@ norm normType mbMask src = unsafeWrapException $
 <http://docs.opencv.org/3.0-last-rst/modules/core/doc/operations_on_arrays.html#norm OpenCV Sphinx doc>
 -}
 normDiff
-    :: NormAbsRel -- ^ Absolute or relative norm.
+    :: MonadError CvException m
+    => NormAbsRel -- ^ Absolute or relative norm.
     -> NormType
     -> Maybe (Mat shape ('S 1) ('S Word8))
        -- ^ Optional operation mask; it must have the same size as the input
        -- array, depth 'Depth_8U' and 1 channel.
     -> Mat shape channels depth -- ^ First input array.
     -> Mat shape channels depth -- ^ Second input array of the same size and type as the first.
-    -> CvExcept Double -- ^ Calculated norm.
+    -> m Double -- ^ Calculated norm.
 normDiff absRel normType mbMask src1 src2 = unsafeWrapException $
     withPtr src1   $ \src1Ptr ->
     withPtr src2   $ \src2Ptr ->
@@ -788,8 +803,8 @@ normDiff absRel normType mbMask src1 src2 = unsafeWrapException $
 <http://docs.opencv.org/3.0-last-rst/modules/core/doc/operations_on_arrays.html#normalize OpenCV Sphinx doc>
 -}
 normalize
-    :: forall shape channels srcDepth dstDepth
-     . (ToDepthDS (Proxy dstDepth))
+    :: forall shape channels srcDepth dstDepth m
+     . (ToDepthDS (Proxy dstDepth), MonadError CvException m)
     => Double
        -- ^ Norm value to normalize to or the lower range boundary in case of
        -- the range normalization.
@@ -799,7 +814,7 @@ normalize
     -> NormType
     -> Maybe (Mat shape ('S 1) ('S Word8)) -- ^ Optional operation mask.
     -> Mat shape channels srcDepth -- ^ Input array.
-    -> CvExcept (Mat shape channels dstDepth)
+    -> m (Mat shape channels dstDepth)
 normalize alpha beta normType mbMask src = unsafeWrapException $ do
     dst <- newEmptyMat
     handleCvException (pure $ unsafeCoerceMat dst) $
@@ -860,17 +875,18 @@ matSumImg = exceptError $
 <http://docs.opencv.org/3.0-last-rst/modules/core/doc/operations_on_arrays.html#sum OpenCV Sphinx doc>
 -}
 matSum
-    :: Mat shape channels depth
+    :: MonadError CvException m
+    => Mat shape channels depth
        -- ^ Input array that must have from 1 to 4 channels.
-    -> CvExcept Scalar
+    -> m Scalar
 matSum src = runCvExceptST $ matSumM =<< unsafeThaw src
 
 matSumM
-    :: (PrimMonad m)
+    :: (PrimMonad m, MonadError CvException m)
     => Mut (Mat shape channels depth) (PrimState m)
        -- ^ Input array that must have from 1 to 4 channels.
-    -> CvExceptT m Scalar
-matSumM srcM = ExceptT $ unsafePrimToPrim $ do
+    -> m Scalar
+matSumM srcM = wrapException $ unsafePrimToPrim $ do
     s <- newScalar zero
     handleCvException (pure s) $
       withPtr srcM $ \srcPtr ->
@@ -884,11 +900,11 @@ matSumM srcM = ExceptT $ unsafePrimToPrim $ do
 <http://docs.opencv.org/3.0-last-rst/modules/core/doc/operations_on_arrays.html#meanstddev OpenCV Sphinx doc>
 -}
 meanStdDev
-    :: (1 <= channels, channels <= 4)
+    :: (1 <= channels, channels <= 4, MonadError CvException m)
     => Mat shape ('S channels) depth
     -> Maybe (Mat shape ('S 1) ('S Word8))
        -- ^ Optional operation mask.
-    -> CvExcept (Scalar, Scalar)
+    -> m (Scalar, Scalar)
 meanStdDev src mask = unsafeWrapException $ do
     mean   <- newScalar $ pure 0
     stddev <- newScalar $ pure 0
@@ -997,8 +1013,9 @@ hconcatImg = exceptError $
 <<doc/generated/examples/hconcatImg.png hconcatImg>>
 -}
 hconcat
-    :: V.Vector (Mat ('S '[rows, 'D]) channels depth)
-    -> CvExcept (Mat ('S '[rows, 'D]) channels depth)
+    :: MonadError CvException m
+    => V.Vector (Mat ('S '[rows, 'D]) channels depth)
+    -> m (Mat ('S '[rows, 'D]) channels depth)
 hconcat mats = unsafeWrapException $ do
     dst <- unsafeCoerceMat <$> newEmptyMat
     handleCvException (pure dst) $
@@ -1034,8 +1051,9 @@ vconcatImg = exceptError $
 <<doc/generated/examples/vconcatImg.png vconcatImg>>
 -}
 vconcat
-    :: V.Vector (Mat ('S '[ 'D, cols ]) channels depth)
-    -> CvExcept (Mat ('S '[ 'D, cols ]) channels depth)
+    :: MonadError CvException m
+    => V.Vector (Mat ('S '[ 'D, cols ]) channels depth)
+    -> m (Mat ('S '[ 'D, cols ]) channels depth)
 vconcat mats = unsafeWrapException $ do
     dst <- unsafeCoerceMat <$> newEmptyMat
     handleCvException (pure dst) $

--- a/opencv/src/OpenCV/Exception.hs
+++ b/opencv/src/OpenCV/Exception.hs
@@ -10,11 +10,6 @@ module OpenCV.Exception
     , ExpectationError(..)
     , CvCppException
 
-      -- * Monadic interface
-    , CvExcept
-    , CvExceptT
-    , pureExcept
-
       -- * Promoting exceptions to errors
     , exceptError
     , exceptErrorIO

--- a/opencv/src/OpenCV/ImgProc/ColorMaps.hsc
+++ b/opencv/src/OpenCV/ImgProc/ColorMaps.hsc
@@ -10,6 +10,7 @@ import "base" Data.Int
 import "base" Data.Word
 import qualified "inline-c" Language.C.Inline as C
 import qualified "inline-c-cpp" Language.C.Inline.Cpp as C
+import "mtl" Control.Monad.Error.Class ( MonadError )
 import "this" OpenCV.Core.Types
 import "this" OpenCV.Internal.C.Inline ( openCvCtx )
 import "this" OpenCV.Internal.C.Types
@@ -143,9 +144,10 @@ colorMapParulaImg  = mkColorMapImg ColorMapParula
 <http://docs.opencv.org/3.0-last-rst/modules/imgproc/doc/colormaps.html#applycolormap OpenCV Sphinx doc>
 -}
 applyColorMap
-    :: ColorMap
+    :: MonadError CvException m
+    => ColorMap
     -> Mat shape ('S 1) ('S Word8)
-    -> CvExcept (Mat shape ('S 3) ('S Word8))
+    -> m (Mat shape ('S 3) ('S Word8))
 applyColorMap colorMap src = unsafeWrapException $ do
     dst <- newEmptyMat
     handleCvException (pure $ unsafeCoerceMat dst) $

--- a/opencv/src/OpenCV/ImgProc/MotionAnalysis.hs
+++ b/opencv/src/OpenCV/ImgProc/MotionAnalysis.hs
@@ -10,13 +10,13 @@ module OpenCV.ImgProc.MotionAnalysis
 
 import "base" Data.Word
 import qualified "inline-c-cpp" Language.C.Inline.Cpp as C
+import "mtl" Control.Monad.Error.Class ( MonadError )
 import "primitive" Control.Monad.Primitive ( PrimMonad, PrimState, unsafePrimToPrim )
 import "this" OpenCV.Core.Types
 import "this" OpenCV.Internal.C.Inline ( openCvCtx )
 import "this" OpenCV.Internal.C.Types
 import "this" OpenCV.Internal.Exception
 import "this" OpenCV.TypeLevel
-import "transformers" Control.Monad.Trans.Except
 
  --------------------------------------------------------------------------------
 
@@ -47,6 +47,7 @@ accumulate
     :: ( srcDepth `In` '[ Word8, Word16, Float, Double ]
        , dstDepth `In` '[ Float, Double ]
        , PrimMonad m
+       , MonadError CvException m
        )
     => Mat ('S '[ height, width ]) channels ('S srcDepth)
        -- ^ @src@: Input image.
@@ -54,8 +55,8 @@ accumulate
        -- ^ @dst@: Accumulator image.
     -> Maybe (Mat ('S '[ height, width ]) ('S 1) ('S Word8))
        -- ^ @mask@: Optional operation mask.
-    -> CvExceptT m ()
-accumulate src dst mbMask = ExceptT $ unsafePrimToPrim $
+    -> m ()
+accumulate src dst mbMask = wrapException $ unsafePrimToPrim $
     withPtr src    $ \srcPtr ->
     withPtr dst    $ \dstPtr ->
     withPtr mbMask $ \maskPtr ->
@@ -88,6 +89,7 @@ accumulateProduct
        , dstDepth `In` '[ Float, Double ]
        , channels `In` '[ 1, 3 ]
        , PrimMonad m
+       , MonadError CvException m
        )
     => Mat ('S '[ height, width ]) ('S channels) ('S srcDepth)
        -- ^ @src1@: First input image.
@@ -97,8 +99,8 @@ accumulateProduct
        -- ^ @dst@: Accumulator image.
     -> Maybe (Mat ('S '[ height, width ]) ('S 1) ('S Word8))
        -- ^ @mask@: Optional operation mask.
-    -> CvExceptT m ()
-accumulateProduct src1 src2 dst mbMask = ExceptT $ unsafePrimToPrim $
+    -> m ()
+accumulateProduct src1 src2 dst mbMask = wrapException $ unsafePrimToPrim $
     withPtr src1   $ \src1Ptr ->
     withPtr src2   $ \src2Ptr ->
     withPtr dst    $ \dstPtr ->
@@ -132,6 +134,7 @@ accumulateSquare
        , dstDepth `In` '[ Float, Double ]
        , channels `In` '[ 1, 3 ]
        , PrimMonad m
+       , MonadError CvException m
        )
     => Mat ('S '[ height, width ]) ('S channels) ('S srcDepth)
        -- ^ @src@: Input image.
@@ -139,8 +142,8 @@ accumulateSquare
        -- ^ @dst@: Accumulator image.
     -> Maybe (Mat ('S '[ height, width ]) ('S 1) ('S Word8))
        -- ^ @mask@: Optional operation mask.
-    -> CvExceptT m ()
-accumulateSquare src dst mbMask = ExceptT $ unsafePrimToPrim $
+    -> m ()
+accumulateSquare src dst mbMask = wrapException $ unsafePrimToPrim $
     withPtr src    $ \srcPtr ->
     withPtr dst    $ \dstPtr ->
     withPtr mbMask $ \maskPtr ->
@@ -175,6 +178,7 @@ accumulateWeighted
        , dstDepth `In` '[ Float, Double ]
        , channels `In` '[ 1, 3 ]
        , PrimMonad m
+       , MonadError CvException m
        )
     => Mat ('S '[ height, width ]) ('S channels) ('S srcDepth)
        -- ^ @src@: Input image.
@@ -183,8 +187,8 @@ accumulateWeighted
     -> Double -- ^ @alpha@: Weight of the input image.
     -> Maybe (Mat ('S '[ height, width ]) ('S 1) ('S Word8))
        -- ^ @mask@: Optional operation mask.
-    -> CvExceptT m ()
-accumulateWeighted src dst alpha mbMask = ExceptT $ unsafePrimToPrim $
+    -> m ()
+accumulateWeighted src dst alpha mbMask = wrapException $ unsafePrimToPrim $
     withPtr src    $ \srcPtr ->
     withPtr dst    $ \dstPtr ->
     withPtr mbMask $ \maskPtr ->

--- a/opencv/src/OpenCV/ImgProc/ObjectDetection.hsc
+++ b/opencv/src/OpenCV/ImgProc/ObjectDetection.hsc
@@ -16,6 +16,7 @@ import "base" Data.Int
 import "base" Data.Word
 import qualified "inline-c" Language.C.Inline as C
 import qualified "inline-c-cpp" Language.C.Inline.Cpp as C
+import "mtl" Control.Monad.Error.Class ( MonadError )
 import "this" OpenCV.Core.Types
 import "this" OpenCV.Internal.C.Inline ( openCvCtx )
 import "this" OpenCV.Internal.C.Types
@@ -191,14 +192,14 @@ matchTemplateImg = exceptError $
 <<doc/generated/examples/matchTemplateImg.png matchTemplateImg>>
 -}
 matchTemplate
-    :: (depth `In` [Word8, Float])
+    :: (depth `In` [Word8, Float], MonadError CvException m)
     => Mat ('S [sh, sw]) ('S channels) ('S depth)
        -- ^ Image where the search is running. It must be 8-bit or 32-bit floating-point.
     -> Mat ('S [th, tw]) ('S channels) ('S depth)
        -- ^ Searched template. It must be not greater than the source image and have the same data type.
     -> MatchTemplateMethod -- ^ Comparison method.
     -> MatchTemplateNormalisation -- ^ Normalization.
-    -> CvExcept (Mat ('S [rh, rw]) ('S 1) ('S Float))
+    -> m (Mat ('S [rh, rw]) ('S 1) ('S Float))
        -- ^ Map of comparison results. It must be single-channel 32-bit
        -- floating-point. If image is \(W \times H\) and templ is
        -- \(w \times h\), then result is \((W-w+1) \times (H-h+1)\).

--- a/opencv/src/OpenCV/Juicy.hs
+++ b/opencv/src/OpenCV/Juicy.hs
@@ -204,7 +204,7 @@ toImage m  = unsafePerformIO $ do
     MatInfo [fromIntegral -> h, fromIntegral -> w] _ _  = matInfo m
 
 -- | An OpenCV 2D-filter preserving the matrix type
-type Filter m h w c d = Mat2D h w c d -> CvExceptT m (Mat2D h w c d)
+type Filter m h w c d = Mat2D h w c d -> m (Mat2D h w c d)
 
 -- | Apply an OpenCV 2D-filter to a JuicyPixels dynamic matrix,
 -- preserving the Juicy pixel encoding
@@ -212,7 +212,7 @@ isoJuicy
     :: forall m. (PrimMonad m)
     => (forall c d h w. Filter m h w c d) -- ^ OpenCV 2D-filter
     -> DynamicImage -- ^ JuicyPixels dynamic image
-    -> CvExceptT m DynamicImage
+    -> m DynamicImage
 isoJuicy f (ImageRGB8 i)    =  ImageRGB8    <$> isoApply f i
 isoJuicy f (ImageRGB16 i)   =  ImageRGB16   <$> isoApply f i
 isoJuicy f (ImageRGBF i)    =  ImageRGBF    <$> isoApply f i

--- a/opencv/src/OpenCV/Photo.hs
+++ b/opencv/src/OpenCV/Photo.hs
@@ -19,6 +19,7 @@ import "base" Data.Int ( Int32 )
 import "base" Data.Word ( Word8 )
 import qualified "inline-c" Language.C.Inline as C
 import qualified "inline-c-cpp" Language.C.Inline.Cpp as C
+import "mtl" Control.Monad.Error.Class ( MonadError )
 import "this" OpenCV.Internal.C.Inline ( openCvCtx )
 import "this" OpenCV.Internal.C.Types ( withPtr )
 import "this" OpenCV.Internal.Exception
@@ -88,14 +89,16 @@ inpaintImg = exceptError $ do
 <<doc/generated/examples/inpaintImg.png inpaintImg>>
 -}
 inpaint
-   :: (channels `In` [1, 3])
+   :: ( channels `In` [1, 3]
+      , MonadError CvException m
+      )
    => Double
       -- ^ inpaintRadius - Radius of a circular neighborhood of each
       -- point inpainted that is considered by the algorithm.
    -> InpaintingMethod
    -> Mat ('S [h, w]) ('S channels) ('S Word8) -- ^ Input image.
    -> Mat ('S [h, w]) ('S 1) ('S Word8) -- ^ Inpainting mask.
-   -> CvExcept (Mat ('S [h, w]) ('S channels) ('S Word8)) -- ^ Output image.
+   -> m (Mat ('S [h, w]) ('S channels) ('S Word8)) -- ^ Output image.
 inpaint inpaintRadius method src inpaintMask = unsafeWrapException $ do
     dst <- newEmptyMat
     handleCvException (pure $ unsafeCoerceMat dst) $
@@ -143,7 +146,8 @@ fastNlMeansDenoisingColoredImg = exceptError $ do
 -}
 
 fastNlMeansDenoisingColored
-   :: Double -- ^ Parameter regulating filter strength for luminance component.
+   :: ( MonadError CvException m )
+   => Double -- ^ Parameter regulating filter strength for luminance component.
              -- Bigger h value perfectly removes noise but also removes image
              -- details, smaller h value preserves details but also preserves
              -- some noise
@@ -158,7 +162,7 @@ fastNlMeansDenoisingColored
              -- Affect performance linearly: greater searchWindowsSize
              -- - greater denoising time. Recommended value 21 pixels
    -> Mat ('S [h, w]) ('S 3) ('S Word8) -- ^ Input image 8-bit 3-channel image.
-   -> CvExcept (Mat ('S [h, w]) ('S 3) ('S Word8))
+   -> m (Mat ('S [h, w]) ('S 3) ('S Word8))
              -- ^ Output image same size and type as input.
 fastNlMeansDenoisingColored h hColor templateWindowSize searchWindowSize src =
   unsafeWrapException $ do
@@ -213,7 +217,8 @@ fastNlMeansDenoisingColoredMultiImg = exceptError $ do
 -}
 
 fastNlMeansDenoisingColoredMulti
-   :: Double -- ^ Parameter regulating filter strength for luminance component.
+   :: ( MonadError CvException m )
+   => Double -- ^ Parameter regulating filter strength for luminance component.
              -- Bigger h value perfectly removes noise but also removes image
              -- details, smaller h value preserves details but also preserves
              -- some noise
@@ -229,7 +234,7 @@ fastNlMeansDenoisingColoredMulti
              -- greater denoising time. Recommended value 21 pixels
    -> V.Vector (Mat ('S [h, w]) ('S 3) ('S Word8))
              -- ^ Vector of odd number of input 8-bit 3-channel images.
-   -> CvExcept (Mat ('S [h, w]) ('S 3) ('S Word8))
+   -> m (Mat ('S [h, w]) ('S 3) ('S Word8))
              -- ^ Output image same size and type as input.
 
 fastNlMeansDenoisingColoredMulti h hColor templateWindowSize searchWindowSize srcVec =
@@ -290,11 +295,12 @@ denoise_TVL1Img = exceptError $ do
 -}
 
 denoise_TVL1
-   :: Double -- ^ details more is more 2
+   :: MonadError CvException m
+   => Double -- ^ details more is more 2
    -> Int32  -- ^ Number of iterations that the algorithm will run
    -> V.Vector (Mat ('S [h, w]) ('S 1) ('S Word8))
              -- ^ Vector of odd number of input 8-bit 3-channel images.
-   -> CvExcept (Mat ('S [h, w]) ('S 1) ('S Word8))
+   -> m (Mat ('S [h, w]) ('S 1) ('S Word8))
              -- ^ Output image same size and type as input.
 
 denoise_TVL1 lambda niters srcVec = unsafeWrapException $ do
@@ -350,8 +356,9 @@ decolorImg = exceptError $ do
 -}
 
 decolor
-   :: Mat ('S [h, w]) ('S 3) ('S Word8) -- ^ Input image.
-   -> CvExcept (Mat ('S [h, w]) ('S 1) ('S Word8), Mat ('S [h, w]) ('S 3) ('S Word8)) -- ^ Output images.
+   :: MonadError CvException m
+   => Mat ('S [h, w]) ('S 3) ('S Word8) -- ^ Input image.
+   -> m (Mat ('S [h, w]) ('S 1) ('S Word8), Mat ('S [h, w]) ('S 3) ('S Word8)) -- ^ Output images.
 
 decolor src = unsafeWrapException $ do
     gray <- newEmptyMat

--- a/opencv/src/OpenCV/Video/MotionAnalysis.hs
+++ b/opencv/src/OpenCV/Video/MotionAnalysis.hs
@@ -75,11 +75,11 @@ carAnim :: Animation (ShapeT [240, 320]) ('S 3) ('S Word8)
 carAnim = carOverhead
 
 mog2Anim :: IO (Animation (ShapeT [240, 320]) ('S 3) ('S Word8))
-mog2Anim = do
+mog2Anim = exceptErrorIO $ do
     mog2 <- newBackgroundSubtractorMOG2 Nothing Nothing Nothing
     forM carOverhead $ \(delay, img) -> do
       fg <- bgSubApply mog2 0.1 img
-      fgBgr <- exceptErrorIO $ pureExcept $ cvtColor gray bgr fg
+      fgBgr <- cvtColor gray bgr fg
       pure (delay, fgBgr)
 @
 

--- a/opencv/test/test.hs
+++ b/opencv/test/test.hs
@@ -152,10 +152,10 @@ testArrayBinOpArgDiff
      . ( testShapeA ~ 'S ['S 2, 'S 3]
        , testShapeB ~ 'S ['S 4, 'S 4]
        )
-    => (Mat 'D 'D 'D -> Mat 'D 'D 'D -> CvExcept (Mat 'D 'D 'D))
+    => (Mat 'D 'D 'D -> Mat 'D 'D 'D -> Either CvException (Mat 'D 'D 'D))
     -> HU.Assertion
 testArrayBinOpArgDiff arrayOp =
-    case runExcept $ arrayOp (relaxMat a) (relaxMat b) of
+    case arrayOp (relaxMat a) (relaxMat b) of
       Left _err -> pure ()
       Right _mat -> assertFailure "result despite different shapes"
   where


### PR DESCRIPTION
This commit removes CvExcept and CvExceptT, and rewrites all OpenCV functions to
use a polymorphic MonadError constraint instead. This has the benefit of easing
the use of the library for users, as they no longer have to worry about lifting
operations (lifting CvExcept into CvExceptT if they are mixing pure and impure
operations), and also removes the cognitive burden of figuring out what
'CvExcept' is and how to work with it.

Also, by being polymorphic in the error representation, we potentially make it
easier to write "one off" OpenCV function calls. Either CvException is an
instance of MonadError CvException, so people can simply pattern match on the
result of an OpenCV call to witness Left/Right constructors, rather than having
to jump through the hoop of runExcept (which incur a transformers dependency -
minor, but annoying overhead).