### PR TITLE
Fix GeometricImgTransform remap on MacOS

### DIFF
--- a/opencv/src/OpenCV/ImgProc/GeometricImgTransform.hsc
+++ b/opencv/src/OpenCV/ImgProc/GeometricImgTransform.hsc
@@ -547,11 +547,12 @@ remap src mapping interpolationMethod borderMode = unsafeWrapException $ do
       withPtr mapping $ \mappingPtr ->
       withPtr borderValue $ \borderValuePtr ->
         [cvExcept|
+          cv::Mat map2;
           cv::remap
             ( *$(Mat * srcPtr)
             , *$(Mat * dstPtr)
             , *$(Mat * mappingPtr)
-            , {}
+            , map2
             , $(int32_t c'interpolation)
             , $(int32_t c'borderMode)
             , *$(Scalar * borderValuePtr)


### PR DESCRIPTION
Fixes #121

But I understand if this is unsatisfactory, and I'm open to the possibility it's just a bandaid around something more sinister going on when compiling with MacOS. Some [discussion on IRC (search `dukedave`)](http://tunes.org/~nef/logs/haskell/18.07.14) suggested it could be an issue with:

* `clang`
* Not correctly using `C++11` (required for `{}`, a [braced-init-list](https://en.cppreference.com/w/cpp/language/list_initialization)
* license issues around pre-C++11 vs. C++11 and later. 