### PR TITLE
Fix wrong NFData instance

### DIFF
--- a/opencv/src/OpenCV/Internal/Core/Types/Mat.hs
+++ b/opencv/src/OpenCV/Internal/Core/Types/Mat.hs
@@ -203,7 +203,7 @@ instance FreezeThaw (Mat shape channels depth) where
     unsafeThaw = pure . Mut
 
 instance NFData (Mat shape channels depth) where
-    rnf _ = ()
+    rnf (Mat !_fptr) = ()
 
 {- | Tests whether a 'Mat' is deserving of its type level attributes
 


### PR DESCRIPTION
:rotating_light: :police_car: :rotating_light: This is the Haskell police :policeman: :stop_sign:

We have found some illegal code on your premises! :mag_right: :open_mouth: It is not law-abiding! :scroll: :point_left: 

The code

    rnf _ = ()

is *always* wrong for *any* instance!

Any request to evaluate to normal form must at least evaluate to weak head normal form.

Even worse in this case, the `ForeignPtr` inside the type is often created by `unsafePerformIO`, and you'd _really_ expect that `rnf` enforces that.