### PR TITLE
Add scoped Mat conversion functions allowing prompt memory freeing.

### DIFF
--- a/opencv/opencv.cabal
+++ b/opencv/opencv.cabal
@@ -65,7 +65,7 @@ library
 
     if impl(ghc < 8.2)
       build-depends:
-          inline-c     >= 0.5.5.5
+          inline-c     >= 0.7.0.0
         , inline-c-cpp >= 0.1
 
       c-sources:
@@ -104,7 +104,7 @@ library
           src/OpenCV/Video/MotionAnalysis.cpp
     else
       build-depends:
-          inline-c     >= 0.6
+          inline-c     >= 0.7.0.0
         , inline-c-cpp >= 0.2.1
 
     cxx-options:       -std=c++11

--- a/opencv/src/OpenCV/Core/Types/Mat/HMat.hs
+++ b/opencv/src/OpenCV/Core/Types/Mat/HMat.hs
@@ -11,6 +11,7 @@ module OpenCV.Core.Types.Mat.HMat
 
     , matToHMat
     , hMatToMat
+    , withHMatAsMat
     ) where
 
 import "this" OpenCV.Internal.Core.Types.Mat.HMat

--- a/opencv/src/OpenCV/Internal/C/FinalizerTH.hs
+++ b/opencv/src/OpenCV/Internal/C/FinalizerTH.hs
@@ -21,11 +21,11 @@ data FinalizerType
    = DeletePtr
    | ReleaseDeletePtr
 
-{- | Generates a function that deletes a C++ object via delete.
+{- | Generates a function that deletes a C++ object via @delete@.
 
 Example:
 
-> mkFinalizer "deleteFoo" "CFoo" ''Foo
+> mkFinalizer DeletePtr "deleteFoo" "CFoo" ''Foo
 
 Generated code (stylized):
 
@@ -38,6 +38,16 @@ Generated code (stylized):
 > }
 
 > foreign import ccall "&deleteFoo" deleteFoo :: FunPtr (Ptr Foo -> IO ())
+
+And
+
+> mkFinalizer ReleaseDeletePtr "deleteFoo" "CFoo" ''Foo
+
+generates an additional
+
+> obj->release();
+
+before the @delete@.
 -}
 mkFinalizer :: FinalizerType -> String -> String -> Name -> DecsQ
 mkFinalizer finalizerType name cType haskellCType = do

--- a/opencv/src/OpenCV/Internal/Core/Types/Mat.hs
+++ b/opencv/src/OpenCV/Internal/Core/Types/Mat.hs
@@ -31,6 +31,7 @@ module OpenCV.Internal.Core.Types.Mat
     , keepMatAliveDuring
     , newEmptyMat
     , newMat
+    , withMat
     , withMatData
     , matToVec
     , vecToMat
@@ -49,6 +50,7 @@ module OpenCV.Internal.Core.Types.Mat
 
     , mkMatM
     , createMat
+    , unsafeFinalizeMat
     , withMatM
     , cloneMatM
     , deallocateMatM
@@ -83,7 +85,7 @@ module OpenCV.Internal.Core.Types.Mat
     , ValidChannels'
     ) where
 
-import "base" Control.Exception ( throwIO, mask_ )
+import "base" Control.Exception ( throwIO, mask_, bracket )
 import "base" Control.Monad ( when )
 import "base" Control.Monad.IO.Class
 import "base" Control.Monad.ST ( ST )
@@ -94,10 +96,11 @@ import qualified "base" Data.List.NonEmpty as NE
 import "base" Data.Maybe
 import "base" Data.Monoid ( (<>) )
 import "base" Data.Proxy
+import "base" Data.Traversable ( for )
 import "base" Data.Word
 import "base" Foreign.C.Types
 import "base" Foreign.ForeignPtr
-    ( ForeignPtr, withForeignPtr, touchForeignPtr, newForeignPtr, newForeignPtr_ )
+    ( ForeignPtr, withForeignPtr, touchForeignPtr, newForeignPtr, newForeignPtr_, finalizeForeignPtr )
 import "base" Foreign.Marshal.Alloc ( alloca )
 import "base" Foreign.Marshal.Array ( allocaArray, peekArray )
 import "base" Foreign.Marshal.Utils ( toBool )
@@ -399,6 +402,44 @@ newMat shape channels depth defValue = do
     channels' = toChannels channels
     depth'    = toDepth depth
     defValue' = toScalar defValue
+
+-- | Frees the data underlying the Mat.
+--
+-- Only use it if you can guarantee that the Mat isn't used
+-- afterwards!
+unsafeFinalizeMat
+    :: Mat shape channels depth -- ^ The matrix to be finalised.
+    -> IO ()
+unsafeFinalizeMat mat = do
+  finalizeForeignPtr (unMat mat)
+
+-- | Like `newMat`, but provides scoped access to the matrix
+-- and it's guaranteed to be freed when this function returns.
+--
+-- Use this instead of `newMat` where you can (where the matrix
+-- needs only lexically scocped life time).
+--
+-- Thus you must not return the matrix outside of the scope.
+withMat
+    :: ( ToShape    shape
+       , ToChannels channels
+       , ToDepth    depth
+       , ToScalar   scalar
+       , MonadError CvException m
+       , MonadIO m
+       )
+    => shape -- ^
+    -> channels
+    -> depth
+    -> scalar
+    -> (Mat (ShapeT shape) (ChannelsT channels) (DepthT depth) -> IO a)
+    -> m a
+withMat shape channels depth defValue action =
+  wrapException $ liftIO $ do
+    bracket
+      (runExceptT $ newMat shape channels depth defValue)
+      (\eMat -> for eMat $ \mat -> unsafeFinalizeMat mat) -- free Mat promptly
+      (\eMat -> for eMat $ \mat -> action mat)
 
 -- TODO (BvD): Move to some Utility module.
 withVector

--- a/opencv/src/OpenCV/Internal/Core/Types/Mat.hs
+++ b/opencv/src/OpenCV/Internal/Core/Types/Mat.hs
@@ -203,7 +203,7 @@ instance FreezeThaw (Mat shape channels depth) where
     unsafeThaw = pure . Mut
 
 instance NFData (Mat shape channels depth) where
-    rnf _ = ()
+    rnf (Mat !_fptr) = ()
 
 {- | Tests whether a 'Mat' is deserving of its type level attributes
 

--- a/overlay.nix
+++ b/overlay.nix
@@ -104,6 +104,17 @@ let
               cp $LICENSE    $out/LICENSE
             '';
         });
+
+      # TODO Remove when https://github.com/fpco/inline-c/pull/78 is available
+      inline-c =
+        overrideCabal super.inline-c (drv : {
+          src = final.fetchgit {
+            url = "https://github.com/fpco/inline-c.git";
+            rev = "b5f93c71161891a901f48aea8db80417b057bc67";
+            sha256 = "0lbrvscbhpbgcsfjfq4mm162s0yxdmwx9h024n8i1riliqpfxw56";
+          };
+          preCompileBuildDriver = "cd inline-c";
+        });
   };
 in  {
   haskell = previous.haskell // {

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,6 +5,9 @@ packages:
 - opencv-extra/
 - opencv-extra-examples/
 flags: {}
+extra-deps:
+# TODO Remove when this is available in the snapshot
+- inline-c-0.7.0.1
 allow-newer: true
 
 extra-lib-dirs:


### PR DESCRIPTION
See commit message for details.

In my application where I call out to CUDA while creating `Mat`s,
using `withHMatAsMat` instead of `hMatToMat` changes memory usage
from linearly increasing (depending on whether I force GC) up to 20 GB
to 250 MB constant memory usage.

**Based on #135, please merge that one first.**