### PR TITLE
Fix `matToHMat emptyMat` segfaulting

### DIFF
--- a/opencv/test/test.hs
+++ b/opencv/test/test.hs
@@ -119,6 +119,7 @@ main = defaultMain $ testGroup "opencv"
             , testGroup "mat -> hmat -> mat -> hmat"
               [ HU.testCase "eye 33 - 1 channel"  $ hMatEncodeDecode eye33_8u_1c
               , HU.testCase "eye 22 - 3 channels" $ hMatEncodeDecode eye22_8u_3c
+              , HU.testCase "empty"  $ hMatEncodeDecode emptyMat
               , hMatEncodeDecodeFP "Lenna.png"
               , hMatEncodeDecodeFP "kikker.jpg"
               ]


### PR DESCRIPTION
Fixes #150.

The `copyFromVec` functions call `dimPositions` to get all the steps and
offsets to copy. That worked well for the non-empty matrices, but for the
empty one, `dimPositions` returns `[[]]`.

The empty matrix can have channels, e.g. `S 1` in

    emptyMat :: Mat (S '[]) (S 1) (S Word8)

Thus in copcode like

    copyFromVec v =
      for_ (zip [0, channels ..] $ dimPositions shape) $ \(posIx, pos) -> do
        let elemPtr = matElemAddress dataPtr (fromIntegral <$> step) pos
        for_ [0 .. channels - 1] $ \channelIx ->
          pokeElemOff elemPtr (fromIntegral channelIx) $ VU.unsafeIndex v (fromIntegral $ posIx + channelIx)

or

    copyToVec = do
      for_ (zip [0,channels..] $ dimPositions shape) $ \(posIx, pos) -> do
        let elemPtr = matElemAddress dataPtr step pos
        for_ [0 .. channels - 1] $ \channelIx -> do
          e <- peekElemOff elemPtr $ fromIntegral channelIx
          VUM.unsafeWrite v (fromIntegral $ posIx + channelIx) e

`dimsPositions (shape = [])` producing `[[]]` results in `pos = []`,
and thus the `poke*`/`peek*` is executed at least once, even though there exist
no elements to run on.
(`matElemAddress` just uses `sum []` in that case, thus producing an invalid
element offset of 0` -- the first element, when there are none.)

This commit fixes it by making `dimPositions [] = []` instead of `[[]]`,
thus the `for_` loops never bring a `pos = []` into being.

Also:

* Ensure that `matElemAddress` checks its precondition.
  The type `Ptr Word8 -> [Int] -> [Int] -> Ptr a` already reveals
  that there must be one / that this function should be partial,
  because which valid element Ptr ought to be
  returned if the given lists are empty?
  `base`'s NonEmpty would be a better type than these lists.
* Add a test against this.
  Before this commit, this test would make the test suite output
      test-opencv: lost signal due to full pipe: 11
  indefinitely.
  With the added `error`, it would be raised.
  With the added fix, it passes.