### PR TITLE
Fix build with the opencv4 flag

### DIFF
--- a/opencv/opencv.cabal
+++ b/opencv/opencv.cabal
@@ -68,7 +68,7 @@ library
         termcriteria.hpp
         video_motion_analysis.hpp
 
-    cxx-options: -std=c++11
+    cxx-options: -std=c++11 -fpermissive 
 
     if os(darwin)
       extra-libraries: c++

--- a/opencv/src/OpenCV/Features2d.hs
+++ b/opencv/src/OpenCV/Features2d.hs
@@ -1,6 +1,7 @@
 {-# language TemplateHaskell #-}
 {-# language QuasiQuotes #-}
 {-# language RecordWildCards #-}
+{-# language CPP #-}
 
 module OpenCV.Features2d
     ( -- * ORB


### PR DESCRIPTION
With these changes, we can build with the opencv4 flag.